### PR TITLE
feat: 決定論的な型付きゲームエンジン基盤を追加

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -4,7 +4,7 @@ import 'game/game_state.dart';
 class Base extends StatelessWidget {
   const Base({required this.base, required this.onPressed, super.key});
 
-  final BaseState base;
+  final IslandState base;
   final VoidCallback onPressed;
 
   @override

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -121,6 +121,9 @@ class GameController extends _$GameController {
     if (_disposed || state.phase != GamePhase.configuration) {
       return;
     }
+    if (!GameConfiguration.isValidIslandCount(totalIslandCount)) {
+      return;
+    }
     final configuration = state.configuration.copyWith(
       totalIslandCount: totalIslandCount,
     );
@@ -151,7 +154,7 @@ class GameController extends _$GameController {
     }
 
     if (selectedIslandId == baseId) {
-      state = state.copyWith(selectedIslandId: null);
+      state = state.clearSelection();
       return;
     }
 
@@ -159,13 +162,13 @@ class GameController extends _$GameController {
     if (source == null ||
         source.faction != Faction.player ||
         source.currentForces <= 1) {
-      state = state.copyWith(selectedIslandId: null);
+      state = state.clearSelection();
       return;
     }
 
     final strength = source.currentForces ~/ 2;
     if (strength <= 0) {
-      state = state.copyWith(selectedIslandId: null);
+      state = state.clearSelection();
       return;
     }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -4,163 +4,238 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'game_loop.dart';
+import 'game_rules.dart';
 import 'game_state.dart';
 
 part 'game_controller.g.dart';
 
+/// Kept as a Random provider so callers of the PR #3 API can continue to
+/// inject `Random(seed)` directly.  GameRules receives the value as an
+/// explicit argument and does not retain global randomness.
 final randomProvider = Provider<Random>((ref) => Random());
+
+final gameConfigurationProvider = Provider<GameConfiguration>(
+  (ref) => GameConfiguration.initial,
+);
+
+final gameRulesProvider = Provider<GameRules>((ref) => const GameRules());
 
 @riverpod
 class GameController extends _$GameController {
   late final GameLoop _gameLoop;
   late final Random _random;
+  late final GameClock _clock;
+  late final GameRules _rules;
+
+  var _disposed = false;
+  int? _lastTickMs;
 
   @override
   GameState build() {
     _gameLoop = ref.read(gameLoopProvider);
     _random = ref.read(randomProvider);
-    ref.onDispose(_gameLoop.stop);
+    _clock = ref.read(gameClockProvider);
+    _rules = ref.read(gameRulesProvider);
+    ref.onDispose(() {
+      _disposed = true;
+      _gameLoop.stop();
+    });
 
-    return GameState(
-      phase: GamePhase.ready,
-      elapsedMs: 0,
-      bases: _generateBases(),
-      selectedBaseId: null,
-      movement: null,
+    return _rules.initialState(
+      configuration: ref.read(gameConfigurationProvider),
+      random: _random,
     );
   }
 
+  /// Starts a match and the production/manual loop.  The first screen in
+  /// PR #3 started immediately on tap; the countdown phase remains available
+  /// through [GameRules.startCountdown] while this compatibility entry point
+  /// keeps that startup behavior unchanged.
   void startGame() {
-    if (state.phase == GamePhase.playing) {
+    if (_disposed || state.phase == GamePhase.playing) {
       return;
     }
 
-    state = state.copyWith(phase: GamePhase.playing);
+    final nextState = switch (state.phase) {
+      GamePhase.configuration => _rules.startCountdown(state),
+      GamePhase.paused => _rules.resumeCountdown(state),
+      _ => state,
+    };
+    if (nextState == state) {
+      return;
+    }
+
+    // Preserve the existing tap-to-play behavior.  Consumers that need a
+    // visible countdown can apply GameRules.tick to the same state instead.
+    state = nextState.copyWith(
+      phase: GamePhase.playing,
+      countdownRemainingMs: 0,
+    );
+    _lastTickMs = _clock.nowMs();
     _gameLoop.start(_tick);
   }
 
+  void pauseGame() {
+    if (_disposed || state.phase != GamePhase.playing) {
+      return;
+    }
+    state = _rules.pause(state);
+    _gameLoop.stop();
+    _lastTickMs = null;
+  }
+
+  void resumeGame() {
+    if (_disposed || state.phase != GamePhase.paused) {
+      return;
+    }
+    final nextState = _rules.resumeCountdown(state);
+    if (nextState == state) {
+      return;
+    }
+    // See startGame: preserve the established immediate-resume UI behavior.
+    state = nextState.copyWith(
+      phase: GamePhase.playing,
+      countdownRemainingMs: 0,
+    );
+    _lastTickMs = _clock.nowMs();
+    _gameLoop.start(_tick);
+  }
+
+  void finish(GameResult result) {
+    if (_disposed) {
+      return;
+    }
+    final nextState = _rules.finish(state, result);
+    if (nextState == state) {
+      return;
+    }
+    state = nextState;
+    _gameLoop.stop();
+    _lastTickMs = null;
+  }
+
+  /// Changes the selected island count before a match starts and regenerates
+  /// only the typed initial state.  Concrete map placement remains a later
+  /// concern; this operation simply makes the setting representable now.
+  void selectIslandCount(int totalIslandCount) {
+    if (_disposed || state.phase != GamePhase.configuration) {
+      return;
+    }
+    final configuration = state.configuration.copyWith(
+      totalIslandCount: totalIslandCount,
+    );
+    state = _rules.initialState(configuration: configuration, random: _random);
+  }
+
+  /// Selects a player island and creates (or retargets the legacy first)
+  /// moving force.  The state itself supports any number of forces; retaining
+  /// the first-force retarget behavior keeps the PR #3 interaction intact.
   void tapBase(int baseId) {
-    final selectedBaseId = state.selectedBaseId;
-    if (selectedBaseId == null) {
-      state = state.copyWith(selectedBaseId: baseId);
+    if (_disposed || state.phase != GamePhase.playing) {
       return;
     }
 
-    final sourceBase = state.bases[selectedBaseId];
-    final scale = (sourceBase.scale / 2).floor();
-    final bases = [...state.bases];
-    bases[selectedBaseId] = sourceBase.copyWith(scale: scale);
+    final selectedIslandId = state.selectedIslandId;
+    final tappedIsland = _findIsland(baseId);
+    if (tappedIsland == null) {
+      return;
+    }
+
+    if (selectedIslandId == null) {
+      if (tappedIsland.faction != Faction.player ||
+          tappedIsland.currentForces <= 1) {
+        return;
+      }
+      state = state.copyWith(selectedIslandId: baseId);
+      return;
+    }
+
+    if (selectedIslandId == baseId) {
+      state = state.copyWith(selectedIslandId: null);
+      return;
+    }
+
+    final source = _findIsland(selectedIslandId);
+    if (source == null ||
+        source.faction != Faction.player ||
+        source.currentForces <= 1) {
+      state = state.copyWith(selectedIslandId: null);
+      return;
+    }
+
+    final strength = source.currentForces ~/ 2;
+    if (strength <= 0) {
+      state = state.copyWith(selectedIslandId: null);
+      return;
+    }
+
+    final islands = [...state.islands];
+    final sourceIndex = islands.indexWhere((island) => island.id == source.id);
+    islands[sourceIndex] = source.copyWith(
+      currentForces: source.currentForces - strength,
+    );
+
+    final existingIndex = state.movingForces.indexWhere(
+      (force) => force.sourceIslandId == source.id,
+    );
+    final movingForces = [...state.movingForces];
+    final nextForce = _rules.createMovingForce(
+      id: existingIndex >= 0
+          ? movingForces[existingIndex].id
+          : _nextMovingForceId,
+      faction: Faction.player,
+      source: source,
+      destination: tappedIsland,
+      strength: strength,
+      departureTimeMs: state.elapsedMs,
+    );
+    if (existingIndex >= 0) {
+      movingForces[existingIndex] = nextForce;
+    } else {
+      movingForces.add(nextForce);
+    }
 
     state = state.copyWith(
-      bases: bases,
-      movement: MovementState(
-        sourceBaseId: selectedBaseId,
-        targetBaseId: baseId,
-        x: sourceBase.x,
-        y: sourceBase.y,
-        deltaX: state.movement?.deltaX ?? 0,
-        deltaY: state.movement?.deltaY ?? 0,
-        scale: scale,
-      ),
+      islands: islands,
+      movingForces: movingForces,
+      selectedIslandId: baseId == source.id ? null : selectedIslandId,
     );
   }
 
   void _tick() {
-    var nextState = state.copyWith(elapsedMs: state.elapsedMs + 50);
-    final movement = state.movement;
-
-    if (movement != null) {
-      final sourceBase = state.bases[movement.sourceBaseId];
-      final targetBase = state.bases[movement.targetBaseId];
-      var deltaX = movement.deltaX;
-      var deltaY = movement.deltaY;
-
-      if (deltaX == 0) {
-        deltaX = _calcDiff(sourceBase.x, targetBase.x);
-      }
-      if (deltaY == 0) {
-        deltaY = _calcDiff(sourceBase.y, targetBase.y);
-      }
-
-      var tankX = movement.x;
-      var tankY = movement.y;
-      if (sourceBase.x >= targetBase.x) {
-        tankX -= deltaX / 100;
-      } else {
-        tankX += deltaX / 100;
-      }
-      if (sourceBase.y >= targetBase.y) {
-        tankY -= deltaY / 100;
-      } else {
-        tankY += deltaY / 100;
-      }
-
-      final arrived =
-          _calcDiff(targetBase.x, tankX) <= 0.01 &&
-          _calcDiff(targetBase.y, tankY) <= 0.01;
-      if (arrived) {
-        final bases = [...nextState.bases];
-        bases[movement.targetBaseId] = targetBase.copyWith(
-          scale: targetBase.scale + movement.scale,
-        );
-        nextState = nextState.copyWith(
-          bases: bases,
-          selectedBaseId: null,
-          movement: null,
-        );
-      } else {
-        nextState = nextState.copyWith(
-          movement: movement.copyWith(
-            x: tankX,
-            y: tankY,
-            deltaX: deltaX,
-            deltaY: deltaY,
-          ),
-        );
-      }
+    if (_disposed || state.phase == GamePhase.paused) {
+      return;
     }
 
-    if (nextState.elapsedMs % 1000 == 0) {
-      nextState = nextState.copyWith(
-        bases: [
-          for (final base in nextState.bases)
-            base.copyWith(scale: base.scale + 1),
-        ],
-      );
+    final now = _clock.nowMs();
+    final previous = _lastTickMs;
+    _lastTickMs = now;
+
+    // Timer callbacks and manual callbacks have the same semantics.  A clock
+    // with fixed time intentionally falls back to one 50ms engine step so the
+    // original ManualGameLoop tests remain useful; advancing a fake clock uses
+    // its exact delta instead.
+    final measuredDelta = _clock is SystemGameClock || previous == null
+        ? 0
+        : now - previous;
+    final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
+    state = _rules.tick(state, deltaMs: deltaMs);
+  }
+
+  IslandState? _findIsland(int id) {
+    for (final island in state.islands) {
+      if (island.id == id) {
+        return island;
+      }
     }
-
-    state = nextState;
+    return null;
   }
 
-  List<BaseState> _generateBases() {
-    return [
-      const BaseState(id: 0, x: 1, y: 1, control: BaseControl.ally, scale: 100),
-      const BaseState(
-        id: 1,
-        x: -1,
-        y: -1,
-        control: BaseControl.enemy,
-        scale: 100,
-      ),
-      for (var id = 2; id <= 9; id++)
-        BaseState(
-          id: id,
-          x: _randomDouble(),
-          y: _randomDouble(),
-          control: BaseControl.neutral,
-          scale: 0,
-        ),
-    ];
-  }
-
-  double _randomDouble() {
-    if (_random.nextBool()) {
-      return _random.nextDouble();
+  int get _nextMovingForceId {
+    var maxId = -1;
+    for (final force in state.movingForces) {
+      maxId = max(maxId, force.id);
     }
-    return _random.nextDouble() - 1;
-  }
-
-  double _calcDiff(double first, double second) {
-    return (first - second).abs();
+    return maxId + 1;
   }
 }

--- a/lib/game/game_controller.g.dart
+++ b/lib/game/game_controller.g.dart
@@ -41,7 +41,7 @@ final class GameControllerProvider
   }
 }
 
-String _$gameControllerHash() => r'6657bec63e8c42966d95e3f0a1b3ecc9693ee668';
+String _$gameControllerHash() => r'5a54fb9de66e995258473ccf68f01641e797bf54';
 
 abstract class _$GameController extends $Notifier<GameState> {
   GameState build();

--- a/lib/game/game_controller.g.dart
+++ b/lib/game/game_controller.g.dart
@@ -41,7 +41,7 @@ final class GameControllerProvider
   }
 }
 
-String _$gameControllerHash() => r'5a54fb9de66e995258473ccf68f01641e797bf54';
+String _$gameControllerHash() => r'527c93cec76711198e3de65ae9f1d1a151906d3b';
 
 abstract class _$GameController extends $Notifier<GameState> {
   GameState build();

--- a/lib/game/game_loop.dart
+++ b/lib/game/game_loop.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+/// The scheduling boundary used by [GameController].  Production uses a
+/// periodic timer, while tests can replace it with [ManualGameLoop] and call
+/// [ManualGameLoop.tick] directly.
 abstract interface class GameLoop {
   bool get isRunning;
 
@@ -16,6 +19,8 @@ final class PeriodicGameLoop implements GameLoop {
 
   final Duration _interval;
   Timer? _timer;
+
+  Duration get interval => _interval;
 
   @override
   bool get isRunning => _timer?.isActive ?? false;
@@ -35,4 +40,47 @@ final class PeriodicGameLoop implements GameLoop {
   }
 }
 
+/// A public manual loop is useful to engine clients that do not want to use a
+/// real timer.  It implements exactly the same callback contract as the
+/// production loop.
+final class ManualGameLoop implements GameLoop {
+  void Function()? _onTick;
+
+  int startCount = 0;
+  int stopCount = 0;
+
+  @override
+  bool get isRunning => _onTick != null;
+
+  @override
+  void start(void Function() onTick) {
+    if (isRunning) {
+      return;
+    }
+    startCount++;
+    _onTick = onTick;
+  }
+
+  @override
+  void stop() {
+    stopCount++;
+    _onTick = null;
+  }
+
+  void tick() => _onTick?.call();
+}
+
+/// Injectable wall-clock boundary.  A fake can subclass this class and
+/// return a fixed or scripted millisecond value for deterministic controller
+/// tests.
+abstract class GameClock {
+  int nowMs() => DateTime.now().millisecondsSinceEpoch;
+}
+
+final class SystemGameClock extends GameClock {}
+
+typedef Clock = GameClock;
+
 final gameLoopProvider = Provider<GameLoop>((ref) => PeriodicGameLoop());
+
+final gameClockProvider = Provider<GameClock>((ref) => SystemGameClock());

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -88,19 +88,20 @@ final class GameRules {
   /// request.  This makes UI commands idempotent while [canTransition]
   /// remains available for validation and tests.
   GameState transitionTo(GameState state, GamePhase target) {
-    if (!canTransition(state.phase, target)) {
+    if (!canTransition(state.phase, target) ||
+        (target == GamePhase.result && state.result == null)) {
       return state;
     }
 
-    return state.copyWith(
+    final nextState = state.copyWith(
       phase: target,
       countdownRemainingMs:
           target == GamePhase.startCountdown ||
               target == GamePhase.resumeCountdown
           ? startCountdownDurationMs
           : 0,
-      result: target == GamePhase.result ? state.result : null,
     );
+    return target == GamePhase.result ? nextState : nextState.clearResult();
   }
 
   GameState startCountdown(
@@ -110,11 +111,12 @@ final class GameRules {
     if (state.phase != GamePhase.configuration) {
       return state;
     }
-    return state.copyWith(
-      phase: GamePhase.startCountdown,
-      countdownRemainingMs: math.max(0, durationMs),
-      result: null,
-    );
+    return state
+        .copyWith(
+          phase: GamePhase.startCountdown,
+          countdownRemainingMs: math.max(0, durationMs),
+        )
+        .clearResult();
   }
 
   GameState resumeCountdown(
@@ -124,10 +126,12 @@ final class GameRules {
     if (state.phase != GamePhase.paused) {
       return state;
     }
-    return state.copyWith(
-      phase: GamePhase.resumeCountdown,
-      countdownRemainingMs: math.max(0, durationMs),
-    );
+    return state
+        .copyWith(
+          phase: GamePhase.resumeCountdown,
+          countdownRemainingMs: math.max(0, durationMs),
+        )
+        .clearResult();
   }
 
   GameState pause(GameState state) {
@@ -135,12 +139,10 @@ final class GameRules {
   }
 
   GameState finish(GameState state, GameResult result) {
-    if (state.phase != GamePhase.playing &&
-        state.phase != GamePhase.paused &&
-        state.phase != GamePhase.resumeCountdown) {
+    if (state.phase != GamePhase.playing) {
       return state;
     }
-    return state.copyWith(phase: GamePhase.result, result: result);
+    return transitionTo(state.copyWith(result: result), GamePhase.result);
   }
 
   /// Advances countdowns and the time-based foundation state.
@@ -224,12 +226,12 @@ final class GameRules {
       );
     }
 
-    return state.copyWith(
+    final nextState = state.copyWith(
       elapsedMs: elapsedMs,
       islands: islands,
       movingForces: remainingForces,
-      selectedIslandId: remainingForces.isEmpty ? null : state.selectedIslandId,
     );
+    return remainingForces.isEmpty ? nextState.clearSelection() : nextState;
   }
 
   MovingForce createMovingForce({
@@ -278,7 +280,7 @@ final class GameRules {
       faction: Faction.neutral,
       size: size,
       currentForces: 0,
-      durability: 0,
+      durability: size.neutralDurability ?? 0,
       capacity: size.capacity,
     );
   }

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -1,0 +1,335 @@
+import 'dart:math' as math;
+
+import 'game_state.dart';
+
+/// Pure, deterministic game-state transitions.
+///
+/// The class has no Riverpod, timer, or Flutter dependency.  Callers provide
+/// the current state and a delta (and, when creating a map, a [math.Random])
+/// and receive a new immutable state.  Concrete dispatch, combat, CPU, and
+/// map-generation rules remain deliberately outside this foundation.
+final class GameRules {
+  const GameRules();
+
+  static const startCountdownDurationMs = 3000;
+  static const movementDurationMs = 5000;
+
+  GameState initialState({
+    GameConfiguration configuration = GameConfiguration.initial,
+    math.Random? random,
+  }) {
+    return GameState(
+      configuration: configuration,
+      phase: GamePhase.configuration,
+      elapsedMs: 0,
+      islands: generateIslands(configuration: configuration, random: random),
+      selectedIslandId: null,
+      movingForces: const <MovingForce>[],
+      result: null,
+      countdownRemainingMs: 0,
+    );
+  }
+
+  /// Alias useful to callers that treat the rules object as a state factory.
+  GameState createInitialState({
+    GameConfiguration configuration = GameConfiguration.initial,
+    math.Random? random,
+  }) {
+    return initialState(configuration: configuration, random: random);
+  }
+
+  List<IslandState> generateIslands({
+    GameConfiguration configuration = GameConfiguration.initial,
+    math.Random? random,
+  }) {
+    final source = random ?? math.Random();
+    final neutralSizes = _neutralSizes(configuration.totalIslandCount);
+    return [
+      const IslandState(
+        id: 0,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 100,
+        durability: 0,
+        capacity: 200,
+      ),
+      const IslandState(
+        id: 1,
+        position: IslandPosition(x: -1, y: -1),
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 100,
+        durability: 0,
+        capacity: 200,
+      ),
+      for (var id = 2; id < configuration.totalIslandCount; id++)
+        _neutralIsland(id: id, size: neutralSizes[id - 2], random: source),
+    ];
+  }
+
+  /// Returns whether a phase change is valid without mutating any state.
+  bool canTransition(GamePhase from, GamePhase to) {
+    if (from == to) {
+      return true;
+    }
+    return switch (from) {
+      GamePhase.configuration => to == GamePhase.startCountdown,
+      GamePhase.startCountdown => to == GamePhase.playing,
+      GamePhase.playing => to == GamePhase.paused || to == GamePhase.result,
+      GamePhase.paused =>
+        to == GamePhase.resumeCountdown || to == GamePhase.configuration,
+      GamePhase.resumeCountdown => to == GamePhase.playing,
+      GamePhase.result => to == GamePhase.configuration,
+    };
+  }
+
+  /// Applies a phase transition, returning the original state for an invalid
+  /// request.  This makes UI commands idempotent while [canTransition]
+  /// remains available for validation and tests.
+  GameState transitionTo(GameState state, GamePhase target) {
+    if (!canTransition(state.phase, target)) {
+      return state;
+    }
+
+    return state.copyWith(
+      phase: target,
+      countdownRemainingMs:
+          target == GamePhase.startCountdown ||
+              target == GamePhase.resumeCountdown
+          ? startCountdownDurationMs
+          : 0,
+      result: target == GamePhase.result ? state.result : null,
+    );
+  }
+
+  GameState startCountdown(
+    GameState state, {
+    int durationMs = startCountdownDurationMs,
+  }) {
+    if (state.phase != GamePhase.configuration) {
+      return state;
+    }
+    return state.copyWith(
+      phase: GamePhase.startCountdown,
+      countdownRemainingMs: math.max(0, durationMs),
+      result: null,
+    );
+  }
+
+  GameState resumeCountdown(
+    GameState state, {
+    int durationMs = startCountdownDurationMs,
+  }) {
+    if (state.phase != GamePhase.paused) {
+      return state;
+    }
+    return state.copyWith(
+      phase: GamePhase.resumeCountdown,
+      countdownRemainingMs: math.max(0, durationMs),
+    );
+  }
+
+  GameState pause(GameState state) {
+    return transitionTo(state, GamePhase.paused);
+  }
+
+  GameState finish(GameState state, GameResult result) {
+    if (state.phase != GamePhase.playing &&
+        state.phase != GamePhase.paused &&
+        state.phase != GamePhase.resumeCountdown) {
+      return state;
+    }
+    return state.copyWith(phase: GamePhase.result, result: result);
+  }
+
+  /// Advances countdowns and the time-based foundation state.
+  GameState tick(GameState state, {required int deltaMs}) {
+    if (deltaMs < 0) {
+      throw ArgumentError.value(deltaMs, 'deltaMs', 'must not be negative');
+    }
+
+    if (state.phase == GamePhase.startCountdown ||
+        state.phase == GamePhase.resumeCountdown) {
+      final remaining = math.max(0, state.countdownRemainingMs - deltaMs);
+      return state.copyWith(
+        phase: remaining == 0 ? GamePhase.playing : state.phase,
+        countdownRemainingMs: remaining,
+      );
+    }
+
+    if (state.phase != GamePhase.playing || deltaMs == 0) {
+      return state;
+    }
+
+    final elapsedMs = state.elapsedMs + deltaMs;
+    var islands = [...state.islands];
+
+    // Resource ticks are represented here as a deterministic time boundary;
+    // concrete ownership/combat rules can later replace this helper without
+    // changing controller or loop orchestration.
+    final resourceTicks = elapsedMs ~/ 1000 - state.elapsedMs ~/ 1000;
+    for (var tick = 0; tick < resourceTicks; tick++) {
+      islands = [
+        for (final island in islands)
+          island.copyWith(
+            currentForces: math.min(island.capacity, island.currentForces + 1),
+          ),
+      ];
+    }
+
+    final remainingForces = <MovingForce>[];
+    for (final force in state.movingForces) {
+      final duration = math.max(1, force.durationMs);
+      final nextProgress = math.min(1.0, force.progress + deltaMs / duration);
+      if (nextProgress >= 1.0) {
+        final targetIndex = islands.indexWhere(
+          (island) => island.id == force.destinationIslandId,
+        );
+        if (targetIndex >= 0) {
+          final target = islands[targetIndex];
+          islands[targetIndex] = target.copyWith(
+            currentForces: math.min(
+              target.capacity,
+              target.currentForces + force.strength,
+            ),
+          );
+        }
+        continue;
+      }
+
+      final source = islands.firstWhere(
+        (island) => island.id == force.sourceIslandId,
+        orElse: () => const IslandState(
+          id: 0,
+          position: IslandPosition(x: 0, y: 0),
+          faction: Faction.neutral,
+        ),
+      );
+      final target = islands.firstWhere(
+        (island) => island.id == force.destinationIslandId,
+        orElse: () => source,
+      );
+      final nextPosition = IslandPosition(
+        x: source.x + (target.x - source.x) * nextProgress,
+        y: source.y + (target.y - source.y) * nextProgress,
+      );
+      remainingForces.add(
+        force.copyWith(
+          position: nextPosition,
+          progress: nextProgress,
+          deltaX: target.x - source.x,
+          deltaY: target.y - source.y,
+        ),
+      );
+    }
+
+    return state.copyWith(
+      elapsedMs: elapsedMs,
+      islands: islands,
+      movingForces: remainingForces,
+      selectedIslandId: remainingForces.isEmpty ? null : state.selectedIslandId,
+    );
+  }
+
+  MovingForce createMovingForce({
+    required int id,
+    required Faction faction,
+    required IslandState source,
+    required IslandState destination,
+    required int strength,
+    int departureTimeMs = 0,
+  }) {
+    final distance = math.sqrt(
+      math.pow(destination.x - source.x, 2) +
+          math.pow(destination.y - source.y, 2),
+    );
+    final durationMs = math.max(
+      1,
+      (movementDurationMs * distance / math.sqrt(8)).round(),
+    );
+    return MovingForce(
+      id: id,
+      faction: faction,
+      sourceIslandId: source.id,
+      destinationIslandId: destination.id,
+      strength: strength,
+      position: source.position,
+      departureTimeMs: departureTimeMs,
+      arrivalTimeMs: departureTimeMs + durationMs,
+      durationMs: durationMs,
+      progress: 0,
+      deltaX: destination.x - source.x,
+      deltaY: destination.y - source.y,
+    );
+  }
+
+  static IslandState _neutralIsland({
+    required int id,
+    required IslandSize size,
+    required math.Random random,
+  }) {
+    return IslandState(
+      id: id,
+      position: IslandPosition(
+        x: _randomCoordinate(random),
+        y: _randomCoordinate(random),
+      ),
+      faction: Faction.neutral,
+      size: size,
+      currentForces: 0,
+      durability: 0,
+      capacity: size.capacity,
+    );
+  }
+
+  static double _randomCoordinate(math.Random random) {
+    return random.nextBool() ? random.nextDouble() : random.nextDouble() - 1;
+  }
+
+  static List<IslandSize> _neutralSizes(int totalIslandCount) {
+    return switch (totalIslandCount) {
+      6 => const [
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.medium,
+        IslandSize.medium,
+      ],
+      8 => const [
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.medium,
+        IslandSize.medium,
+        IslandSize.large,
+        IslandSize.large,
+      ],
+      10 => const [
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.medium,
+        IslandSize.medium,
+        IslandSize.large,
+        IslandSize.large,
+      ],
+      12 => const [
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.small,
+        IslandSize.medium,
+        IslandSize.medium,
+        IslandSize.medium,
+        IslandSize.medium,
+        IslandSize.large,
+        IslandSize.large,
+      ],
+      _ => throw ArgumentError.value(
+        totalIslandCount,
+        'totalIslandCount',
+        'must be one of 6, 8, 10, or 12',
+      ),
+    };
+  }
+}

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -88,20 +88,25 @@ final class GameRules {
   /// request.  This makes UI commands idempotent while [canTransition]
   /// remains available for validation and tests.
   GameState transitionTo(GameState state, GamePhase target) {
+    if (state.phase == target) {
+      return state;
+    }
     if (!canTransition(state.phase, target) ||
         (target == GamePhase.result && state.result == null)) {
       return state;
     }
 
-    final nextState = state.copyWith(
-      phase: target,
+    if (target == GamePhase.result) {
+      return state.finishWithResult(state.result!);
+    }
+    return state.transitionToPhase(
+      target,
       countdownRemainingMs:
           target == GamePhase.startCountdown ||
               target == GamePhase.resumeCountdown
           ? startCountdownDurationMs
           : 0,
     );
-    return target == GamePhase.result ? nextState : nextState.clearResult();
   }
 
   GameState startCountdown(
@@ -111,12 +116,10 @@ final class GameRules {
     if (state.phase != GamePhase.configuration) {
       return state;
     }
-    return state
-        .copyWith(
-          phase: GamePhase.startCountdown,
-          countdownRemainingMs: math.max(0, durationMs),
-        )
-        .clearResult();
+    return state.transitionToPhase(
+      GamePhase.startCountdown,
+      countdownRemainingMs: math.max(0, durationMs),
+    );
   }
 
   GameState resumeCountdown(
@@ -126,12 +129,10 @@ final class GameRules {
     if (state.phase != GamePhase.paused) {
       return state;
     }
-    return state
-        .copyWith(
-          phase: GamePhase.resumeCountdown,
-          countdownRemainingMs: math.max(0, durationMs),
-        )
-        .clearResult();
+    return state.transitionToPhase(
+      GamePhase.resumeCountdown,
+      countdownRemainingMs: math.max(0, durationMs),
+    );
   }
 
   GameState pause(GameState state) {
@@ -139,10 +140,11 @@ final class GameRules {
   }
 
   GameState finish(GameState state, GameResult result) {
-    if (state.phase != GamePhase.playing) {
+    if (state.phase != GamePhase.playing ||
+        !canTransition(state.phase, GamePhase.result)) {
       return state;
     }
-    return transitionTo(state.copyWith(result: result), GamePhase.result);
+    return state.finishWithResult(result);
   }
 
   /// Advances countdowns and the time-based foundation state.

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -233,7 +233,31 @@ final class GameRules {
       islands: islands,
       movingForces: remainingForces,
     );
-    return remainingForces.isEmpty ? nextState.clearSelection() : nextState;
+
+    // A selected source remains active while the player is choosing a
+    // destination.  Only clear it after an existing dispatch has completed,
+    // or when the source can no longer dispatch under the current rules.
+    final selectedIsland = nextState.selectedIslandId == null
+        ? null
+        : nextState.islands.firstWhere(
+            (island) => island.id == nextState.selectedIslandId,
+            orElse: () => const IslandState(
+              id: -1,
+              position: IslandPosition(x: 0, y: 0),
+              faction: Faction.neutral,
+            ),
+          );
+    final selectionInvalid =
+        nextState.selectedIslandId != null &&
+        (selectedIsland == null ||
+            selectedIsland.id == -1 ||
+            selectedIsland.faction != Faction.player ||
+            selectedIsland.currentForces <= 1);
+    final dispatchCompleted =
+        state.movingForces.isNotEmpty && remainingForces.isEmpty;
+    return dispatchCompleted || selectionInvalid
+        ? nextState.clearSelection()
+        : nextState;
   }
 
   MovingForce createMovingForce({

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -4,8 +4,6 @@
 /// transitions usable by a later renderer, a CPU player, and deterministic
 /// tests without having to construct a widget tree.
 
-const _unchanged = Object();
-
 enum GamePhase {
   configuration,
   startCountdown,
@@ -80,23 +78,31 @@ final class GameConfiguration {
   static const allowedIslandCounts = <int>[6, 8, 10, 12];
   static const defaultIslandCount = 10;
 
-  const GameConfiguration({int? totalIslandCount, int? islandCount})
-    : totalIslandCount = totalIslandCount ?? islandCount ?? defaultIslandCount,
-      assert(
-        (totalIslandCount ?? islandCount ?? defaultIslandCount) == 6 ||
-            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 8 ||
-            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 10 ||
-            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 12,
-        'totalIslandCount must be one of 6, 8, 10, or 12',
+  factory GameConfiguration({int? totalIslandCount, int? islandCount}) {
+    final count = totalIslandCount ?? islandCount ?? defaultIslandCount;
+    if (!isValidIslandCount(count)) {
+      throw ArgumentError.value(
+        count,
+        'totalIslandCount',
+        'must be one of 6, 8, 10, or 12',
       );
+    }
+    return GameConfiguration._(count);
+  }
+
+  const GameConfiguration._(this.totalIslandCount);
 
   final int totalIslandCount;
+
+  static bool isValidIslandCount(int count) {
+    return count == 6 || count == 8 || count == 10 || count == 12;
+  }
 
   /// Alternate spelling used by map-facing code.
   int get islandCount => totalIslandCount;
 
   /// The initial selection required by the rules document.
-  static const initial = GameConfiguration();
+  static const initial = GameConfiguration._(defaultIslandCount);
   static const defaultConfiguration = initial;
 
   GameConfiguration copyWith({int? totalIslandCount, int? islandCount}) {
@@ -190,7 +196,7 @@ class IslandState {
     int? id,
     double? x,
     double? y,
-    Object? position = _unchanged,
+    IslandPosition? position,
     Faction? faction,
     BaseControl? control,
     IslandSize? size,
@@ -202,9 +208,7 @@ class IslandState {
     int? scale,
   }) {
     final nextFaction = faction ?? control ?? this.faction;
-    final nextPosition = identical(position, _unchanged)
-        ? this.position
-        : position as IslandPosition;
+    final nextPosition = position ?? this.position;
     final positioned = x == null && y == null
         ? nextPosition
         : nextPosition.copyWith(x: x, y: y);
@@ -212,7 +216,9 @@ class IslandState {
     final nextDurability =
         durability ??
         currentDurability ??
-        (scale == null ? this.durability : scale);
+        (scale == null || this.faction != Faction.neutral
+            ? this.durability
+            : scale);
 
     return IslandState(
       id: id ?? this.id,
@@ -330,7 +336,7 @@ class MovingForce {
     int? targetBaseId,
     int? strength,
     int? scale,
-    Object? position = _unchanged,
+    IslandPosition? position,
     double? x,
     double? y,
     int? departureTimeMs,
@@ -341,9 +347,7 @@ class MovingForce {
     double? deltaX,
     double? deltaY,
   }) {
-    final nextPosition = identical(position, _unchanged)
-        ? this.position
-        : position as IslandPosition;
+    final nextPosition = position ?? this.position;
     final positionWithCoordinates = x == null && y == null
         ? nextPosition
         : nextPosition.copyWith(x: x, y: y);
@@ -477,7 +481,7 @@ final class GameState {
     int? selectedIslandId,
     int? selectedBaseId,
     List<MovingForce>? movingForces,
-    Object? movement = _unchanged,
+    MovingForce? movement,
     GameResult? result,
     int? countdownRemainingMs,
   }) : configuration = configuration ?? GameConfiguration.initial,
@@ -485,14 +489,16 @@ final class GameState {
        selectedIslandId = selectedIslandId ?? selectedBaseId,
        movingForces = List.unmodifiable(
          movingForces ??
-             (identical(movement, _unchanged)
+             (movement == null
                  ? const <MovingForce>[]
-                 : movement == null
-                 ? const <MovingForce>[]
-                 : <MovingForce>[movement as MovingForce]),
+                 : <MovingForce>[movement]),
        ),
        result = result,
-       countdownRemainingMs = countdownRemainingMs ?? 0;
+       countdownRemainingMs = countdownRemainingMs ?? 0 {
+    if (phase == GamePhase.result && result == null) {
+      throw StateError('A result phase must include a GameResult');
+    }
+  }
 
   final GameConfiguration configuration;
   final GamePhase phase;
@@ -511,46 +517,84 @@ final class GameState {
   bool get isCountdown =>
       phase == GamePhase.startCountdown || phase == GamePhase.resumeCountdown;
 
-  static const _unchanged = Object();
-
   GameState copyWith({
     GameConfiguration? configuration,
     GamePhase? phase,
     int? elapsedMs,
     List<IslandState>? islands,
     List<BaseState>? bases,
-    Object? selectedIslandId = _unchanged,
-    Object? selectedBaseId = _unchanged,
+    int? selectedIslandId,
+    int? selectedBaseId,
     List<MovingForce>? movingForces,
-    Object? movement = _unchanged,
-    Object? result = _unchanged,
+    GameResult? result,
     int? countdownRemainingMs,
   }) {
-    final nextSelected = !identical(selectedIslandId, _unchanged)
-        ? selectedIslandId as int?
-        : !identical(selectedBaseId, _unchanged)
-        ? selectedBaseId as int?
-        : this.selectedIslandId;
-    final nextMovingForces =
-        movingForces ??
-        (!identical(movement, _unchanged)
-            ? movement == null
-                  ? const <MovingForce>[]
-                  : <MovingForce>[movement as MovingForce]
-            : this.movingForces);
-
     return GameState(
       configuration: configuration ?? this.configuration,
       phase: phase ?? this.phase,
       elapsedMs: elapsedMs ?? this.elapsedMs,
       islands: islands ?? bases ?? this.islands,
-      selectedIslandId: nextSelected,
-      movingForces: nextMovingForces,
-      result: identical(result, _unchanged)
-          ? this.result
-          : result as GameResult?,
+      selectedIslandId:
+          selectedIslandId ?? selectedBaseId ?? this.selectedIslandId,
+      movingForces: movingForces ?? this.movingForces,
+      result: result ?? this.result,
       countdownRemainingMs: countdownRemainingMs ?? this.countdownRemainingMs,
     );
+  }
+
+  /// Clears the nullable selection through a typed API rather than a dynamic
+  /// sentinel in [copyWith].
+  GameState clearSelection() {
+    return GameState(
+      configuration: configuration,
+      phase: phase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: null,
+      movingForces: movingForces,
+      result: result,
+      countdownRemainingMs: countdownRemainingMs,
+    );
+  }
+
+  /// Clears all moving forces through a typed API.
+  GameState clearMovingForces() {
+    return GameState(
+      configuration: configuration,
+      phase: phase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: const <MovingForce>[],
+      result: result,
+      countdownRemainingMs: countdownRemainingMs,
+    );
+  }
+
+  /// Clears a result only while the state is not in the result phase.  This
+  /// preserves the invariant that a result phase always carries its result.
+  GameState clearResult() {
+    if (phase == GamePhase.result) {
+      throw StateError('A result phase cannot clear its GameResult');
+    }
+    return GameState(
+      configuration: configuration,
+      phase: phase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: movingForces,
+      result: null,
+      countdownRemainingMs: countdownRemainingMs,
+    );
+  }
+
+  /// Compatibility helper for callers that used the old singular movement
+  /// field while keeping the update statically typed.
+  GameState copyWithMovement(MovingForce? movement) {
+    return movement == null
+        ? clearMovingForces()
+        : copyWith(movingForces: <MovingForce>[movement]);
   }
 
   @override

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -495,8 +495,10 @@ final class GameState {
        ),
        result = result,
        countdownRemainingMs = countdownRemainingMs ?? 0 {
-    if (phase == GamePhase.result && result == null) {
-      throw StateError('A result phase must include a GameResult');
+    if ((phase == GamePhase.result) != (result != null)) {
+      throw StateError(
+        'Only a result phase may include a GameResult, and it must include one',
+      );
     }
   }
 
@@ -539,6 +541,46 @@ final class GameState {
       movingForces: movingForces ?? this.movingForces,
       result: result ?? this.result,
       countdownRemainingMs: countdownRemainingMs ?? this.countdownRemainingMs,
+    );
+  }
+
+  /// Atomically enters the result phase with its result.  This avoids a
+  /// transient non-result phase that carries a result.
+  GameState finishWithResult(GameResult nextResult) {
+    return GameState(
+      configuration: configuration,
+      phase: GamePhase.result,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: movingForces,
+      result: nextResult,
+      countdownRemainingMs: 0,
+    );
+  }
+
+  /// Atomically enters a non-result phase without a result.  This is used for
+  /// reset/configuration transitions from a completed match.
+  GameState transitionToPhase(
+    GamePhase nextPhase, {
+    int countdownRemainingMs = 0,
+  }) {
+    if (nextPhase == GamePhase.result) {
+      throw ArgumentError.value(
+        nextPhase,
+        'nextPhase',
+        'use finishWithResult for the result phase',
+      );
+    }
+    return GameState(
+      configuration: configuration,
+      phase: nextPhase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: movingForces,
+      result: null,
+      countdownRemainingMs: countdownRemainingMs,
     );
   }
 

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -1,126 +1,595 @@
-enum GamePhase { ready, playing }
+/// Immutable value objects used by the game engine.
+///
+/// The model intentionally does not depend on Flutter.  This keeps the rule
+/// transitions usable by a later renderer, a CPU player, and deterministic
+/// tests without having to construct a widget tree.
 
-enum BaseControl { ally, enemy, neutral }
+const _unchanged = Object();
 
-final class BaseState {
-  const BaseState({
-    required this.id,
-    required this.x,
-    required this.y,
-    required this.control,
-    required this.scale,
-  });
+enum GamePhase {
+  configuration,
+  startCountdown,
+  playing,
+  paused,
+  resumeCountdown,
+  result;
 
-  final int id;
+  /// Compatibility name used by the first Riverpod screen.
+  static const ready = configuration;
+
+  /// Short aliases make phase checks read naturally at call sites while the
+  /// full names remain the canonical representation in persisted state.
+  static const countdown = startCountdown;
+  static const resuming = resumeCountdown;
+}
+
+enum Faction {
+  player,
+  cpu,
+  neutral;
+
+  /// Names used by the original PR #3 model.
+  static const ally = player;
+  static const enemy = cpu;
+}
+
+/// `BaseControl` is kept as a source-compatible alias for the PR #3 screen.
+typedef BaseControl = Faction;
+
+/// A stable position in the normalized game coordinate space.
+final class IslandPosition {
+  const IslandPosition({required this.x, required this.y});
+
   final double x;
   final double y;
-  final BaseControl control;
-  final int scale;
 
-  BaseState copyWith({
-    int? id,
-    double? x,
-    double? y,
-    BaseControl? control,
-    int? scale,
-  }) {
-    return BaseState(
-      id: id ?? this.id,
-      x: x ?? this.x,
-      y: y ?? this.y,
-      control: control ?? this.control,
-      scale: scale ?? this.scale,
+  IslandPosition copyWith({double? x, double? y}) {
+    return IslandPosition(x: x ?? this.x, y: y ?? this.y);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is IslandPosition && other.x == x && other.y == y;
+  }
+
+  @override
+  int get hashCode => Object.hash(x, y);
+}
+
+/// Compatibility aliases for consumers that prefer a generic position name.
+typedef GamePosition = IslandPosition;
+typedef Position = IslandPosition;
+
+enum IslandSize {
+  small(neutralDurability: 10, capacity: 50),
+  medium(neutralDurability: 30, capacity: 100),
+  large(neutralDurability: 50, capacity: 150),
+  headquarters(neutralDurability: null, capacity: 200);
+
+  const IslandSize({required this.neutralDurability, required this.capacity});
+
+  final int? neutralDurability;
+  final int capacity;
+
+  /// A base is the legacy name for a headquarters island.
+  static const base = headquarters;
+}
+
+/// The selectable island-count configuration for a match.
+final class GameConfiguration {
+  static const allowedIslandCounts = <int>[6, 8, 10, 12];
+  static const defaultIslandCount = 10;
+
+  const GameConfiguration({int? totalIslandCount, int? islandCount})
+    : totalIslandCount = totalIslandCount ?? islandCount ?? defaultIslandCount,
+      assert(
+        (totalIslandCount ?? islandCount ?? defaultIslandCount) == 6 ||
+            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 8 ||
+            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 10 ||
+            (totalIslandCount ?? islandCount ?? defaultIslandCount) == 12,
+        'totalIslandCount must be one of 6, 8, 10, or 12',
+      );
+
+  final int totalIslandCount;
+
+  /// Alternate spelling used by map-facing code.
+  int get islandCount => totalIslandCount;
+
+  /// The initial selection required by the rules document.
+  static const initial = GameConfiguration();
+  static const defaultConfiguration = initial;
+
+  GameConfiguration copyWith({int? totalIslandCount, int? islandCount}) {
+    return GameConfiguration(
+      totalIslandCount:
+          totalIslandCount ?? islandCount ?? this.totalIslandCount,
     );
   }
 
   @override
   bool operator ==(Object other) {
-    return other is BaseState &&
-        other.id == id &&
-        other.x == x &&
-        other.y == y &&
-        other.control == control &&
-        other.scale == scale;
+    return other is GameConfiguration &&
+        other.totalIslandCount == totalIslandCount;
   }
 
   @override
-  int get hashCode => Object.hash(id, x, y, control, scale);
+  int get hashCode => totalIslandCount.hashCode;
 }
 
-final class MovementState {
-  const MovementState({
-    required this.sourceBaseId,
-    required this.targetBaseId,
-    required this.x,
-    required this.y,
-    required this.deltaX,
-    required this.deltaY,
-    required this.scale,
-  });
-
-  final int sourceBaseId;
-  final int targetBaseId;
-  final double x;
-  final double y;
-  final double deltaX;
-  final double deltaY;
-  final int scale;
-
-  MovementState copyWith({
-    int? sourceBaseId,
-    int? targetBaseId,
+/// A typed island state.  Neutral islands use [durability], while owned
+/// islands use [currentForces].  Keeping both values allows later combat rules
+/// to model a damaged neutral island without introducing a dynamic payload.
+class IslandState {
+  const IslandState({
+    required this.id,
     double? x,
     double? y,
-    double? deltaX,
-    double? deltaY,
+    IslandPosition? position,
+    Faction? faction,
+    BaseControl? control,
+    IslandSize? size,
+    int? currentForces,
+    int? forces,
+    int? durability,
+    int? currentDurability,
+    int? scale,
+    int? capacity,
+  }) : _x = x ?? 0,
+       _y = y ?? 0,
+       _position = position,
+       faction = faction ?? control ?? Faction.neutral,
+       size =
+           size ??
+           (id == 0 || id == 1 ? IslandSize.headquarters : IslandSize.small),
+       currentForces = currentForces ?? forces ?? scale ?? 0,
+       durability =
+           durability ??
+           currentDurability ??
+           ((faction ?? control ?? Faction.neutral) == Faction.neutral
+               ? scale ?? forces ?? 0
+               : 0),
+       capacity =
+           capacity ??
+           ((size == IslandSize.headquarters ||
+                   (size == null && (id == 0 || id == 1)))
+               ? 200
+               : size == IslandSize.medium
+               ? 100
+               : size == IslandSize.large
+               ? 150
+               : 50);
+
+  final int id;
+  final double _x;
+  final double _y;
+  final IslandPosition? _position;
+  final Faction faction;
+  final IslandSize size;
+  final int currentForces;
+  final int durability;
+  final int capacity;
+
+  double get x => _position?.x ?? _x;
+  double get y => _position?.y ?? _y;
+
+  IslandPosition get position => IslandPosition(x: x, y: y);
+
+  /// Canonical and descriptive aliases for [currentForces].
+  int get forces => currentForces;
+  int get currentStrength => currentForces;
+
+  /// Canonical alias for the neutral-island value.
+  int get currentDurability => durability;
+
+  /// Legacy PR #3 names.  They intentionally expose the force value so the
+  /// existing renderer can continue to watch the same fields.
+  Faction get control => faction;
+  int get scale => currentForces;
+
+  IslandState copyWith({
+    int? id,
+    double? x,
+    double? y,
+    Object? position = _unchanged,
+    Faction? faction,
+    BaseControl? control,
+    IslandSize? size,
+    int? currentForces,
+    int? forces,
+    int? durability,
+    int? currentDurability,
+    int? capacity,
     int? scale,
   }) {
-    return MovementState(
-      sourceBaseId: sourceBaseId ?? this.sourceBaseId,
-      targetBaseId: targetBaseId ?? this.targetBaseId,
-      x: x ?? this.x,
-      y: y ?? this.y,
-      deltaX: deltaX ?? this.deltaX,
-      deltaY: deltaY ?? this.deltaY,
-      scale: scale ?? this.scale,
+    final nextFaction = faction ?? control ?? this.faction;
+    final nextPosition = identical(position, _unchanged)
+        ? this.position
+        : position as IslandPosition;
+    final positioned = x == null && y == null
+        ? nextPosition
+        : nextPosition.copyWith(x: x, y: y);
+    final nextForces = currentForces ?? forces ?? scale ?? this.currentForces;
+    final nextDurability =
+        durability ??
+        currentDurability ??
+        (scale == null ? this.durability : scale);
+
+    return IslandState(
+      id: id ?? this.id,
+      x: positioned.x,
+      y: positioned.y,
+      position: positioned,
+      faction: nextFaction,
+      size: size ?? this.size,
+      currentForces: nextForces,
+      durability: nextDurability,
+      capacity: capacity ?? this.capacity,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is IslandState &&
+        other.id == id &&
+        other.position == position &&
+        other.faction == faction &&
+        other.size == size &&
+        other.currentForces == currentForces &&
+        other.durability == durability &&
+        other.capacity == capacity;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    position,
+    faction,
+    size,
+    currentForces,
+    durability,
+    capacity,
+  );
+}
+
+/// Compatibility value object for the original PR #3 constructor.  The
+/// canonical state is [IslandState]; this subtype exists only so existing UI
+/// and tests can continue to use `const BaseState(x: ..., scale: ...)`.
+final class BaseState extends IslandState {
+  const BaseState({
+    required super.id,
+    required double x,
+    required double y,
+    required BaseControl control,
+    required int scale,
+  }) : super(
+         x: x,
+         y: y,
+         faction: control,
+         size: id == 0 || id == 1 ? IslandSize.headquarters : IslandSize.small,
+         currentForces: scale,
+         durability: control == Faction.neutral ? scale : 0,
+         capacity: control == Faction.neutral ? 50 : 200,
+       );
+}
+
+/// A force that is currently travelling between two islands.
+class MovingForce {
+  const MovingForce({
+    this.id = 0,
+    this.faction = Faction.player,
+    required this.sourceIslandId,
+    required this.destinationIslandId,
+    required this.strength,
+    double? x,
+    double? y,
+    IslandPosition? position,
+    this.departureTimeMs = 0,
+    this.arrivalTimeMs = movementDefaultArrivalTimeMs,
+    this.durationMs = movementDefaultDurationMs,
+    this.progress = 0,
+    this.deltaX = 0,
+    this.deltaY = 0,
+  }) : _x = x ?? 0,
+       _y = y ?? 0,
+       _position = position;
+
+  static const movementDefaultDurationMs = 5000;
+  static const movementDefaultArrivalTimeMs = movementDefaultDurationMs;
+
+  final int id;
+  final Faction faction;
+  final int sourceIslandId;
+  final int destinationIslandId;
+  final int strength;
+  final double _x;
+  final double _y;
+  final IslandPosition? _position;
+  final int departureTimeMs;
+  final int arrivalTimeMs;
+  final int durationMs;
+  final double progress;
+  final double deltaX;
+  final double deltaY;
+
+  double get x => _position?.x ?? _x;
+  double get y => _position?.y ?? _y;
+
+  IslandPosition get position => IslandPosition(x: x, y: y);
+
+  /// Legacy PR #3 names.
+  int get sourceBaseId => sourceIslandId;
+  int get targetBaseId => destinationIslandId;
+  int get scale => strength;
+
+  MovingForce copyWith({
+    int? id,
+    Faction? faction,
+    int? sourceIslandId,
+    int? sourceBaseId,
+    int? destinationIslandId,
+    int? targetBaseId,
+    int? strength,
+    int? scale,
+    Object? position = _unchanged,
+    double? x,
+    double? y,
+    int? departureTimeMs,
+    int? startTimeMs,
+    int? arrivalTimeMs,
+    int? durationMs,
+    double? progress,
+    double? deltaX,
+    double? deltaY,
+  }) {
+    final nextPosition = identical(position, _unchanged)
+        ? this.position
+        : position as IslandPosition;
+    final positionWithCoordinates = x == null && y == null
+        ? nextPosition
+        : nextPosition.copyWith(x: x, y: y);
+    return MovingForce(
+      id: id ?? this.id,
+      faction: faction ?? this.faction,
+      sourceIslandId: sourceIslandId ?? sourceBaseId ?? this.sourceIslandId,
+      destinationIslandId:
+          destinationIslandId ?? targetBaseId ?? this.destinationIslandId,
+      strength: strength ?? scale ?? this.strength,
+      x: positionWithCoordinates.x,
+      y: positionWithCoordinates.y,
+      position: positionWithCoordinates,
+      departureTimeMs: departureTimeMs ?? startTimeMs ?? this.departureTimeMs,
+      arrivalTimeMs: arrivalTimeMs ?? this.arrivalTimeMs,
+      durationMs: durationMs ?? this.durationMs,
+      progress: progress ?? this.progress,
+      deltaX: deltaX ?? this.deltaX,
+      deltaY: deltaY ?? this.deltaY,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MovingForce &&
+        other.id == id &&
+        other.faction == faction &&
+        other.sourceIslandId == sourceIslandId &&
+        other.destinationIslandId == destinationIslandId &&
+        other.strength == strength &&
+        other.position == position &&
+        other.departureTimeMs == departureTimeMs &&
+        other.arrivalTimeMs == arrivalTimeMs &&
+        other.durationMs == durationMs &&
+        other.progress == progress &&
+        other.deltaX == deltaX &&
+        other.deltaY == deltaY;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    faction,
+    sourceIslandId,
+    destinationIslandId,
+    strength,
+    position,
+    departureTimeMs,
+    arrivalTimeMs,
+    durationMs,
+    progress,
+    deltaX,
+    deltaY,
+  );
+}
+
+/// Compatibility value object for PR #3's constructor and field names.
+final class MovementState extends MovingForce {
+  const MovementState({
+    required int sourceBaseId,
+    required int targetBaseId,
+    required double x,
+    required double y,
+    required double deltaX,
+    required double deltaY,
+    required int scale,
+  }) : super(
+         sourceIslandId: sourceBaseId,
+         destinationIslandId: targetBaseId,
+         strength: scale,
+         x: x,
+         y: y,
+         deltaX: deltaX,
+         deltaY: deltaY,
+       );
+}
+
+enum GameResultType {
+  victory,
+  defeat,
+  draw;
+
+  static const win = victory;
+  static const loss = defeat;
+}
+
+typedef GameOutcome = GameResultType;
+
+final class GameResult {
+  const GameResult({required this.type, required this.elapsedMs, this.winner});
+
+  const GameResult.victory({
+    required int elapsedMs,
+    Faction winner = Faction.player,
+  }) : this(type: GameResultType.victory, elapsedMs: elapsedMs, winner: winner);
+
+  const GameResult.defeat({
+    required int elapsedMs,
+    Faction winner = Faction.cpu,
+  }) : this(type: GameResultType.defeat, elapsedMs: elapsedMs, winner: winner);
+
+  const GameResult.draw({required int elapsedMs})
+    : this(type: GameResultType.draw, elapsedMs: elapsedMs);
+
+  final GameResultType type;
+  final int elapsedMs;
+  final Faction? winner;
+
+  GameResultType get outcome => type;
+  GameResultType get resultType => type;
+
+  @override
+  bool operator ==(Object other) {
+    return other is GameResult &&
+        other.type == type &&
+        other.elapsedMs == elapsedMs &&
+        other.winner == winner;
+  }
+
+  @override
+  int get hashCode => Object.hash(type, elapsedMs, winner);
 }
 
 final class GameState {
   GameState({
     required this.phase,
     required this.elapsedMs,
-    required List<BaseState> bases,
-    required this.selectedBaseId,
-    required this.movement,
-  }) : bases = List.unmodifiable(bases);
+    GameConfiguration? configuration,
+    List<IslandState>? islands,
+    List<BaseState>? bases,
+    int? selectedIslandId,
+    int? selectedBaseId,
+    List<MovingForce>? movingForces,
+    Object? movement = _unchanged,
+    GameResult? result,
+    int? countdownRemainingMs,
+  }) : configuration = configuration ?? GameConfiguration.initial,
+       islands = List.unmodifiable(islands ?? bases ?? const <IslandState>[]),
+       selectedIslandId = selectedIslandId ?? selectedBaseId,
+       movingForces = List.unmodifiable(
+         movingForces ??
+             (identical(movement, _unchanged)
+                 ? const <MovingForce>[]
+                 : movement == null
+                 ? const <MovingForce>[]
+                 : <MovingForce>[movement as MovingForce]),
+       ),
+       result = result,
+       countdownRemainingMs = countdownRemainingMs ?? 0;
 
+  final GameConfiguration configuration;
   final GamePhase phase;
   final int elapsedMs;
-  final List<BaseState> bases;
-  final int? selectedBaseId;
-  final MovementState? movement;
+  final List<IslandState> islands;
+  final int? selectedIslandId;
+  final List<MovingForce> movingForces;
+  final GameResult? result;
+  final int countdownRemainingMs;
+
+  /// PR #3 compatibility getters.
+  List<IslandState> get bases => islands;
+  int? get selectedBaseId => selectedIslandId;
+  MovingForce? get movement => movingForces.isEmpty ? null : movingForces.first;
+
+  bool get isCountdown =>
+      phase == GamePhase.startCountdown || phase == GamePhase.resumeCountdown;
 
   static const _unchanged = Object();
 
   GameState copyWith({
+    GameConfiguration? configuration,
     GamePhase? phase,
     int? elapsedMs,
+    List<IslandState>? islands,
     List<BaseState>? bases,
+    Object? selectedIslandId = _unchanged,
     Object? selectedBaseId = _unchanged,
+    List<MovingForce>? movingForces,
     Object? movement = _unchanged,
+    Object? result = _unchanged,
+    int? countdownRemainingMs,
   }) {
+    final nextSelected = !identical(selectedIslandId, _unchanged)
+        ? selectedIslandId as int?
+        : !identical(selectedBaseId, _unchanged)
+        ? selectedBaseId as int?
+        : this.selectedIslandId;
+    final nextMovingForces =
+        movingForces ??
+        (!identical(movement, _unchanged)
+            ? movement == null
+                  ? const <MovingForce>[]
+                  : <MovingForce>[movement as MovingForce]
+            : this.movingForces);
+
     return GameState(
+      configuration: configuration ?? this.configuration,
       phase: phase ?? this.phase,
       elapsedMs: elapsedMs ?? this.elapsedMs,
-      bases: bases ?? this.bases,
-      selectedBaseId: identical(selectedBaseId, _unchanged)
-          ? this.selectedBaseId
-          : selectedBaseId as int?,
-      movement: identical(movement, _unchanged)
-          ? this.movement
-          : movement as MovementState?,
+      islands: islands ?? bases ?? this.islands,
+      selectedIslandId: nextSelected,
+      movingForces: nextMovingForces,
+      result: identical(result, _unchanged)
+          ? this.result
+          : result as GameResult?,
+      countdownRemainingMs: countdownRemainingMs ?? this.countdownRemainingMs,
     );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GameState &&
+        other.configuration == configuration &&
+        other.phase == phase &&
+        other.elapsedMs == elapsedMs &&
+        _listEquals(other.islands, islands) &&
+        other.selectedIslandId == selectedIslandId &&
+        _listEquals(other.movingForces, movingForces) &&
+        other.result == result &&
+        other.countdownRemainingMs == countdownRemainingMs;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    configuration,
+    phase,
+    elapsedMs,
+    Object.hashAll(islands),
+    selectedIslandId,
+    Object.hashAll(movingForces),
+    result,
+    countdownRemainingMs,
+  );
+
+  static bool _listEquals<T>(List<T> first, List<T> second) {
+    if (identical(first, second)) {
+      return true;
+    }
+    if (first.length != second.length) {
+      return false;
+    }
+    for (var index = 0; index < first.length; index++) {
+      if (first[index] != second[index]) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -104,6 +104,23 @@ void main() {
     expect(state.bases[0].scale, 50);
   });
 
+  test('preserves a selected source across ticks before destination tap', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    controller.tapBase(0);
+
+    loop.tick();
+    loop.tick();
+
+    expect(container.read(gameControllerProvider).selectedBaseId, 0);
+    expect(container.read(gameControllerProvider).movement, isNull);
+
+    controller.tapBase(1);
+    final state = container.read(gameControllerProvider);
+    expect(state.selectedBaseId, 0);
+    expect(state.movement, isNotNull);
+  });
+
   test('ticks movement and resolves it at the target', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -20,10 +20,10 @@ void main() {
   test('configuration exposes the supported counts and default selection', () {
     expect(GameConfiguration.allowedIslandCounts, [6, 8, 10, 12]);
     expect(GameConfiguration.initial.totalIslandCount, 10);
-    expect(const GameConfiguration(islandCount: 6).totalIslandCount, 6);
+    expect(GameConfiguration(islandCount: 6).totalIslandCount, 6);
     expect(
       () => GameConfiguration(totalIslandCount: 7),
-      throwsA(isA<AssertionError>()),
+      throwsA(isA<ArgumentError>()),
     );
   });
 
@@ -46,6 +46,67 @@ void main() {
     expect(updated.capacity, 100);
     expect(IslandSize.medium.capacity, 100);
   });
+
+  test(
+    'initial neutral island composition carries typed durability values',
+    () {
+      const expectedSizes = <int, List<IslandSize>>{
+        6: [
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.medium,
+          IslandSize.medium,
+        ],
+        8: [
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.medium,
+          IslandSize.medium,
+          IslandSize.large,
+          IslandSize.large,
+        ],
+        10: [
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.medium,
+          IslandSize.medium,
+          IslandSize.large,
+          IslandSize.large,
+        ],
+        12: [
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.small,
+          IslandSize.medium,
+          IslandSize.medium,
+          IslandSize.medium,
+          IslandSize.medium,
+          IslandSize.large,
+          IslandSize.large,
+        ],
+      };
+
+      for (final entry in expectedSizes.entries) {
+        final islands = rules
+            .initialState(
+              configuration: GameConfiguration(totalIslandCount: entry.key),
+              random: Random(entry.key),
+            )
+            .islands
+            .skip(2)
+            .toList();
+
+        expect(islands.map((island) => island.size), entry.value);
+        for (final island in islands) {
+          expect(island.durability, island.size.neutralDurability);
+          expect(island.capacity, island.size.capacity);
+        }
+      }
+    },
+  );
 
   test('state holds multiple typed moving forces immutably', () {
     const forces = [
@@ -93,6 +154,58 @@ void main() {
     expect(rules.pause(initial), same(initial));
     expect(rules.tick(countdown, deltaMs: 99).phase, GamePhase.startCountdown);
     expect(rules.tick(countdown, deltaMs: 100).phase, GamePhase.playing);
+  });
+
+  test('phase transition table and result invariant agree for every phase', () {
+    final initial = rules.initialState(random: Random(4));
+    final playing = initial.copyWith(phase: GamePhase.playing);
+    final paused = rules.pause(playing);
+    final resuming = rules.resumeCountdown(paused, durationMs: 100);
+    final result = const GameResult.draw(elapsedMs: 10);
+
+    const validTransitions = <GamePhase, Set<GamePhase>>{
+      GamePhase.configuration: {
+        GamePhase.configuration,
+        GamePhase.startCountdown,
+      },
+      GamePhase.startCountdown: {GamePhase.startCountdown, GamePhase.playing},
+      GamePhase.playing: {
+        GamePhase.playing,
+        GamePhase.paused,
+        GamePhase.result,
+      },
+      GamePhase.paused: {
+        GamePhase.paused,
+        GamePhase.resumeCountdown,
+        GamePhase.configuration,
+      },
+      GamePhase.resumeCountdown: {GamePhase.resumeCountdown, GamePhase.playing},
+      GamePhase.result: {GamePhase.result, GamePhase.configuration},
+    };
+    for (final from in GamePhase.values) {
+      for (final to in GamePhase.values) {
+        expect(
+          rules.canTransition(from, to),
+          validTransitions[from]!.contains(to),
+          reason: '$from -> $to',
+        );
+      }
+    }
+
+    expect(rules.transitionTo(playing, GamePhase.result), same(playing));
+    final finished = rules.finish(playing, result);
+    expect(finished.phase, GamePhase.result);
+    expect(finished.result, result);
+    expect(rules.finish(paused, result), same(paused));
+    expect(rules.finish(resuming, result), same(resuming));
+    expect(
+      rules.transitionTo(finished, GamePhase.configuration).result,
+      isNull,
+    );
+    expect(
+      () => GameState(phase: GamePhase.result, elapsedMs: 0),
+      throwsStateError,
+    );
   });
 
   test(
@@ -175,5 +288,50 @@ void main() {
     loop.tick();
 
     expect(container.read(gameControllerProvider).elapsedMs, 125);
+  });
+
+  test('nullable state values are cleared through typed APIs', () {
+    const force = MovingForce(
+      id: 1,
+      sourceIslandId: 0,
+      destinationIslandId: 1,
+      strength: 5,
+    );
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      selectedIslandId: 0,
+      movingForces: const [force],
+    ).copyWith(result: const GameResult.draw(elapsedMs: 0));
+
+    expect(state.clearSelection().selectedIslandId, isNull);
+    expect(state.clearMovingForces().movingForces, isEmpty);
+    expect(state.clearResult().result, isNull);
+    expect(state.copyWithMovement(null).movingForces, isEmpty);
+  });
+
+  test('controller ignores invalid island-count selections', () {
+    final loop = ManualGameLoop();
+    final container = ProviderContainer(
+      overrides: [
+        gameLoopProvider.overrideWithValue(loop),
+        randomProvider.overrideWithValue(Random(8)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.selectIslandCount(7);
+    expect(
+      container.read(gameControllerProvider).configuration.totalIslandCount,
+      10,
+    );
+
+    controller.selectIslandCount(6);
+    expect(
+      container.read(gameControllerProvider).configuration.totalIslandCount,
+      6,
+    );
+    expect(container.read(gameControllerProvider).islands, hasLength(6));
   });
 }

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -193,9 +193,11 @@ void main() {
     }
 
     expect(rules.transitionTo(playing, GamePhase.result), same(playing));
+    expect(rules.transitionTo(playing, GamePhase.playing), same(playing));
     final finished = rules.finish(playing, result);
     expect(finished.phase, GamePhase.result);
     expect(finished.result, result);
+    expect(rules.transitionTo(finished, GamePhase.result), same(finished));
     expect(rules.finish(paused, result), same(paused));
     expect(rules.finish(resuming, result), same(resuming));
     expect(
@@ -205,6 +207,26 @@ void main() {
     expect(
       () => GameState(phase: GamePhase.result, elapsedMs: 0),
       throwsStateError,
+    );
+  });
+
+  test('countdown self-transitions preserve remaining time', () {
+    final initial = rules.initialState(random: Random(5));
+    final countdown = rules.startCountdown(initial, durationMs: 1000);
+    final partialStart = rules.tick(countdown, deltaMs: 400);
+    final paused = rules.pause(rules.tick(countdown, deltaMs: 1000));
+    final resume = rules.resumeCountdown(paused, durationMs: 1200);
+    final partialResume = rules.tick(resume, deltaMs: 500);
+
+    expect(partialStart.countdownRemainingMs, 600);
+    expect(
+      rules.transitionTo(partialStart, GamePhase.startCountdown),
+      same(partialStart),
+    );
+    expect(partialResume.countdownRemainingMs, 700);
+    expect(
+      rules.transitionTo(partialResume, GamePhase.resumeCountdown),
+      same(partialResume),
     );
   });
 
@@ -302,12 +324,34 @@ void main() {
       elapsedMs: 0,
       selectedIslandId: 0,
       movingForces: const [force],
-    ).copyWith(result: const GameResult.draw(elapsedMs: 0));
+    );
+    final resultState = state.finishWithResult(
+      const GameResult.draw(elapsedMs: 0),
+    );
 
     expect(state.clearSelection().selectedIslandId, isNull);
     expect(state.clearMovingForces().movingForces, isEmpty);
     expect(state.clearResult().result, isNull);
     expect(state.copyWithMovement(null).movingForces, isEmpty);
+    expect(resultState.phase, GamePhase.result);
+    expect(resultState.result, isNotNull);
+    expect(
+      () => GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        result: const GameResult.draw(elapsedMs: 0),
+      ),
+      throwsStateError,
+    );
+    expect(
+      () => state.copyWith(result: const GameResult.draw(elapsedMs: 0)),
+      throwsStateError,
+    );
+    expect(
+      () => resultState.copyWith(phase: GamePhase.playing),
+      throwsStateError,
+    );
+    expect(() => resultState.clearResult(), throwsStateError);
   });
 
   test('controller ignores invalid island-count selections', () {

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -1,0 +1,179 @@
+import 'dart:math';
+
+import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/game/game_state.dart';
+import 'package:conquest/game/game_controller.dart';
+import 'package:conquest/game/game_loop.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class FixedClock extends GameClock {
+  int value = 0;
+
+  @override
+  int nowMs() => value;
+}
+
+void main() {
+  const rules = GameRules();
+
+  test('configuration exposes the supported counts and default selection', () {
+    expect(GameConfiguration.allowedIslandCounts, [6, 8, 10, 12]);
+    expect(GameConfiguration.initial.totalIslandCount, 10);
+    expect(const GameConfiguration(islandCount: 6).totalIslandCount, 6);
+    expect(
+      () => GameConfiguration(totalIslandCount: 7),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
+  test('value objects provide immutable copy updates', () {
+    const position = IslandPosition(x: 0.25, y: -0.5);
+    const island = IslandState(
+      id: 4,
+      position: position,
+      faction: Faction.player,
+      size: IslandSize.medium,
+      currentForces: 12,
+      capacity: 100,
+    );
+
+    final updated = island.copyWith(currentForces: 20);
+
+    expect(island.currentForces, 12);
+    expect(updated.currentForces, 20);
+    expect(updated.position, position);
+    expect(updated.capacity, 100);
+    expect(IslandSize.medium.capacity, 100);
+  });
+
+  test('state holds multiple typed moving forces immutably', () {
+    const forces = [
+      MovingForce(
+        id: 1,
+        faction: Faction.player,
+        sourceIslandId: 0,
+        destinationIslandId: 2,
+        strength: 10,
+      ),
+      MovingForce(
+        id: 2,
+        faction: Faction.cpu,
+        sourceIslandId: 1,
+        destinationIslandId: 3,
+        strength: 12,
+      ),
+    ];
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      movingForces: forces,
+    );
+
+    expect(state.movingForces, hasLength(2));
+    expect(state.movingForces, isA<List<MovingForce>>());
+    expect(() => state.movingForces.add(forces.first), throwsUnsupportedError);
+    expect(state.movement, forces.first);
+  });
+
+  test('valid and invalid phase transitions are explicit and immutable', () {
+    final initial = rules.initialState(random: Random(3));
+    expect(
+      rules.canTransition(GamePhase.configuration, GamePhase.startCountdown),
+      isTrue,
+    );
+    expect(
+      rules.canTransition(GamePhase.configuration, GamePhase.paused),
+      isFalse,
+    );
+
+    final countdown = rules.startCountdown(initial, durationMs: 100);
+    expect(countdown.phase, GamePhase.startCountdown);
+    expect(countdown.countdownRemainingMs, 100);
+    expect(rules.pause(initial), same(initial));
+    expect(rules.tick(countdown, deltaMs: 99).phase, GamePhase.startCountdown);
+    expect(rules.tick(countdown, deltaMs: 100).phase, GamePhase.playing);
+  });
+
+  test(
+    'fixed random seed reproduces initial state and fixed time reproduces ticks',
+    () {
+      final first = rules.initialState(random: Random(99));
+      final second = rules.initialState(random: Random(99));
+
+      expect(first, second);
+
+      final playing = rules.tick(
+        rules.startCountdown(first, durationMs: 0),
+        deltaMs: 0,
+      );
+      final firstTick = rules.tick(playing, deltaMs: 1250);
+      final secondTick = rules.tick(playing, deltaMs: 1250);
+
+      expect(playing.phase, GamePhase.playing);
+      expect(firstTick, secondTick);
+      expect(firstTick.elapsedMs, 1250);
+      expect(firstTick.islands.first.currentForces, 101);
+    },
+  );
+
+  test('a moving force advances by time and arrives deterministically', () {
+    const source = IslandState(
+      id: 0,
+      position: IslandPosition(x: -1, y: -1),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 40,
+      capacity: 200,
+    );
+    const target = IslandState(
+      id: 1,
+      position: IslandPosition(x: 1, y: 1),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 10,
+      capacity: 200,
+    );
+    final force = rules.createMovingForce(
+      id: 0,
+      faction: Faction.player,
+      source: source,
+      destination: target,
+      strength: 15,
+    );
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: [source, target],
+      movingForces: [force],
+    );
+
+    final halfway = rules.tick(state, deltaMs: force.durationMs ~/ 2);
+    expect(halfway.movingForces, hasLength(1));
+    expect(halfway.movingForces.single.progress, closeTo(0.5, 0.01));
+
+    final arrived = rules.tick(halfway, deltaMs: force.durationMs);
+    expect(arrived.movingForces, isEmpty);
+    expect(arrived.islands.last.currentForces, 32);
+  });
+
+  test('controller uses an injected clock with a manual loop', () {
+    final clock = FixedClock();
+    final loop = ManualGameLoop();
+    final container = ProviderContainer(
+      overrides: [
+        gameClockProvider.overrideWithValue(clock),
+        gameLoopProvider.overrideWithValue(loop),
+        randomProvider.overrideWithValue(Random(7)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    clock.value = 125;
+    loop.tick();
+
+    expect(container.read(gameControllerProvider).elapsedMs, 125);
+  });
+}


### PR DESCRIPTION
## 概要

設定・島・複数の移動部隊・進行フェーズ・結果を型付き immutable state で表現し、後続のゲーム機能を決定論的に実装・テストできる GameEngine 基盤を追加します。

## 背景・目的

PR #3 で導入した Riverpod の状態管理を拡張し、マップ・移動・戦闘・CPU・UIを互いに疎結合で実装できる純粋ルール境界と、時刻・乱数・周期処理を差し替え可能な構造を整えます。

## 対応内容

- 合計島数、島、陣営、島サイズ、複数移動部隊、進行フェーズ、勝敗結果の型付き immutable model を追加
- `GameController` の orchestration と pure `GameRules` の状態遷移を分離
- 時刻・乱数・GameLoop を注入可能にし、production の周期処理と test の manual tick を交換可能に変更
- Riverpod provider dispose 時の loop 停止と PR #3 の起動・状態監視互換を維持
- 値オブジェクト、島構成、複数部隊、phase/result 不変条件、固定時刻・固定seed、loop lifecycle の回帰テストを追加

## 主な設計判断

- ゲーム状態は型付き immutable object として保持し、nullable state の解除も型付き専用 API で表現
- phase と result の双方向不変条件を state 層で保証し、遷移は pure rules を正本にする
- 具体的な点対称マップ、出兵・戦闘・勝敗判定、CPU、UIは Issue の対象外として実装しない

## 受け入れ条件との対応

- [x] 設定、島、部隊、フェーズ、結果を型付き状態で表現
- [x] 移動部隊を immutable な複数件 collection として保持
- [x] 非型付きゲーム状態を導入せず、型安全な更新 API を提供
- [x] 固定時刻・固定乱数 seed で同じ状態遷移を再現
- [x] production periodic loop と test manual tick を差し替え可能
- [x] Riverpod provider 破棄時に GameLoop を停止
- [x] PR #3 の起動・状態監視と既存 UI adapter を維持
- [x] `fvm flutter analyze` と `fvm flutter test` が成功

## 検証

- `fvm dart run build_runner build --delete-conflicting-outputs`: 成功
- `fvm flutter analyze`: 成功（No issues found）
- `fvm flutter test test/game_rules_test.dart`: 成功
- `fvm flutter test`: 成功（22件）
- `git diff --check origin/main...HEAD`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `5fb0ee7b1d6fb147cdc26dddd8448ec755cbe04a`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `0225d3368700c1a2c3ba084a25a847e85016b711`、fix HEAD: `5fb0ee7b1d6fb147cdc26dddd8448ec755cbe04a`）
- Required checks: 対象なし

## 残存リスク

承認済みスコープ内の既知リスクなし。点対称マップ、具体的な出兵・移動・戦闘・勝敗、CPU、UIは後続Issueの対象です。

Closes #6