### PR TITLE
feat: implement symmetric island map generation

### DIFF
--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -42,6 +42,10 @@ class GameController extends _$GameController {
 
   @override
   GameState build() {
+    // Riverpod may invoke the disposal callbacks while rebuilding this
+    // notifier after a watched viewport changes.  A completed rebuild is a
+    // live controller again; the final disposal still leaves this true.
+    _disposed = false;
     _gameLoop = ref.read(gameLoopProvider);
     _random = ref.read(randomProvider);
     _clock = ref.read(gameClockProvider);

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -51,16 +51,19 @@ class GameController extends _$GameController {
     _clock = ref.read(gameClockProvider);
     _rules = ref.read(gameRulesProvider);
     final viewport = ref.watch(mapViewportProvider);
-    final configuration = ref.read(gameConfigurationProvider);
+    final providerConfiguration = ref.read(gameConfigurationProvider);
     ref.onDispose(() {
       _disposed = true;
       _gameLoop.stop();
     });
 
     final previousState = stateOrNull;
+    // The provider supplies the initial match configuration. Once a state
+    // exists, its configuration is the match's source of truth so viewport
+    // rebuilds cannot replace a user-selected island count.
+    final configuration = previousState?.configuration ?? providerConfiguration;
     if (previousState != null &&
-        previousState.phase != GamePhase.configuration &&
-        _cachedConfiguration == configuration) {
+        previousState.phase != GamePhase.configuration) {
       _cachedViewport = viewport;
       if (previousState.phase == GamePhase.playing && !_gameLoop.isRunning) {
         // A dependency rebuild runs the disposal callback before build. Keep

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -57,6 +57,20 @@ class GameController extends _$GameController {
       _gameLoop.stop();
     });
 
+    final previousState = stateOrNull;
+    if (previousState != null &&
+        previousState.phase != GamePhase.configuration &&
+        _cachedConfiguration == configuration) {
+      _cachedViewport = viewport;
+      if (previousState.phase == GamePhase.playing && !_gameLoop.isRunning) {
+        // A dependency rebuild runs the disposal callback before build. Keep
+        // an in-progress match alive by resuming its loop after rebuilding.
+        _lastTickMs = _clock.nowMs();
+        _gameLoop.start(_tick);
+      }
+      return previousState;
+    }
+
     return _initialStateFor(configuration: configuration, viewport: viewport);
   }
 

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -20,15 +20,25 @@ final gameConfigurationProvider = Provider<GameConfiguration>(
 
 final gameRulesProvider = Provider<GameRules>((ref) => const GameRules());
 
+/// The renderer supplies the SafeArea-sized layout viewport before the
+/// controller is created.  Keeping it as a provider makes the map generator
+/// and Home use one source of truth without coupling GameRules to Flutter.
+final mapViewportProvider = Provider<IslandMapViewport>(
+  (ref) => GameRules.defaultMapViewport,
+);
+
 @riverpod
 class GameController extends _$GameController {
-  late final GameLoop _gameLoop;
-  late final Random _random;
-  late final GameClock _clock;
-  late final GameRules _rules;
+  late GameLoop _gameLoop;
+  late Random _random;
+  late GameClock _clock;
+  late GameRules _rules;
 
   var _disposed = false;
   int? _lastTickMs;
+  IslandMapViewport? _cachedViewport;
+  GameConfiguration? _cachedConfiguration;
+  GameState? _cachedInitialState;
 
   @override
   GameState build() {
@@ -36,15 +46,14 @@ class GameController extends _$GameController {
     _random = ref.read(randomProvider);
     _clock = ref.read(gameClockProvider);
     _rules = ref.read(gameRulesProvider);
+    final viewport = ref.watch(mapViewportProvider);
+    final configuration = ref.read(gameConfigurationProvider);
     ref.onDispose(() {
       _disposed = true;
       _gameLoop.stop();
     });
 
-    return _rules.initialState(
-      configuration: ref.read(gameConfigurationProvider),
-      random: _random,
-    );
+    return _initialStateFor(configuration: configuration, viewport: viewport);
   }
 
   /// Starts a match and the production/manual loop.  The first screen in
@@ -127,7 +136,37 @@ class GameController extends _$GameController {
     final configuration = state.configuration.copyWith(
       totalIslandCount: totalIslandCount,
     );
-    state = _rules.initialState(configuration: configuration, random: _random);
+    state = _initialStateFor(
+      configuration: configuration,
+      viewport: ref.read(mapViewportProvider),
+    );
+  }
+
+  GameState _initialStateFor({
+    required GameConfiguration configuration,
+    required IslandMapViewport viewport,
+  }) {
+    if (_cachedInitialState != null &&
+        _cachedConfiguration == configuration &&
+        _cachedViewport == viewport) {
+      return _cachedInitialState!;
+    }
+
+    final nextState =
+        _rules.tryInitialState(
+          configuration: configuration,
+          random: _random,
+          viewport: viewport,
+        ) ??
+        GameState(
+          configuration: configuration,
+          phase: GamePhase.configuration,
+          elapsedMs: 0,
+        );
+    _cachedConfiguration = configuration;
+    _cachedViewport = viewport;
+    _cachedInitialState = nextState;
+    return nextState;
   }
 
   /// Selects a player island and creates (or retargets the legacy first)

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -20,6 +20,16 @@ final class IslandMapViewport {
   bool get isValid =>
       width.isFinite && height.isFinite && width > 0 && height > 0;
 
+  @override
+  bool operator ==(Object other) {
+    return other is IslandMapViewport &&
+        other.width == width &&
+        other.height == height;
+  }
+
+  @override
+  int get hashCode => Object.hash(width, height);
+
   IslandMapRect rectFor(IslandState island) {
     return rectForPosition(island.position, island.size);
   }
@@ -116,7 +126,7 @@ final class GameRules {
     math.Random? random,
     IslandMapViewport viewport = defaultMapViewport,
   }) {
-    return GameState(
+    return _initialState(
       configuration: configuration,
       phase: GamePhase.configuration,
       elapsedMs: 0,
@@ -125,6 +135,43 @@ final class GameRules {
         random: random,
         viewport: viewport,
       ),
+      selectedIslandId: null,
+      movingForces: const <MovingForce>[],
+      result: null,
+      countdownRemainingMs: 0,
+    );
+  }
+
+  /// Creates an initial state when the supplied viewport can fit a complete
+  /// map, or returns null after the bounded generation budget is exhausted.
+  /// This is used by the renderer-facing controller so an unusually small
+  /// layout fails closed without displaying overlapping islands.
+  GameState? tryInitialState({
+    GameConfiguration configuration = GameConfiguration.initial,
+    math.Random? random,
+    IslandMapViewport viewport = defaultMapViewport,
+    int maxAttempts = defaultMapGenerationAttempts,
+    int? maxRetries,
+    int maxPairAttempts = defaultPairPlacementAttempts,
+    int? maxPairRetries,
+  }) {
+    final islands = tryGenerateIslands(
+      configuration: configuration,
+      random: random,
+      viewport: viewport,
+      maxAttempts: maxAttempts,
+      maxRetries: maxRetries,
+      maxPairAttempts: maxPairAttempts,
+      maxPairRetries: maxPairRetries,
+    );
+    if (islands == null) {
+      return null;
+    }
+    return _initialState(
+      configuration: configuration,
+      phase: GamePhase.configuration,
+      elapsedMs: 0,
+      islands: islands,
       selectedIslandId: null,
       movingForces: const <MovingForce>[],
       result: null,
@@ -218,8 +265,11 @@ final class GameRules {
         'must have positive dimensions',
       );
     }
-    if (viewport.width < headquartersWidgetSize ||
-        viewport.height < headquartersWidgetSize) {
+    final playerHeadquarters = viewport.rectFor(_playerHeadquarters);
+    final cpuHeadquarters = viewport.rectFor(_cpuHeadquarters);
+    if (!playerHeadquarters.isWithin(viewport) ||
+        !cpuHeadquarters.isWithin(viewport) ||
+        playerHeadquarters.overlaps(cpuHeadquarters)) {
       return null;
     }
 
@@ -580,6 +630,28 @@ final class GameRules {
       currentForces: 0,
       durability: size.neutralDurability ?? 0,
       capacity: size.capacity,
+    );
+  }
+
+  static GameState _initialState({
+    required GameConfiguration configuration,
+    required GamePhase phase,
+    required int elapsedMs,
+    required List<IslandState> islands,
+    required int? selectedIslandId,
+    required List<MovingForce> movingForces,
+    required GameResult? result,
+    required int countdownRemainingMs,
+  }) {
+    return GameState(
+      configuration: configuration,
+      phase: phase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: movingForces,
+      result: result,
+      countdownRemainingMs: countdownRemainingMs,
     );
   }
 

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -6,13 +6,29 @@ import 'game_state.dart';
 ///
 /// The class has no Riverpod, timer, or Flutter dependency.  Callers provide
 /// the current state and a delta (and, when creating a map, a [math.Random])
-/// and receive a new immutable state.  Concrete dispatch, combat, CPU, and
-/// map-generation rules remain deliberately outside this foundation.
+/// and receive a new immutable state.  Concrete dispatch, combat, and CPU
+/// rules remain deliberately outside this foundation.  Map generation lives
+/// here because it is a deterministic, renderer-independent part of the
+/// initial state.
 final class GameRules {
   const GameRules();
 
   static const startCountdownDurationMs = 3000;
   static const movementDurationMs = 5000;
+
+  /// Normalized alignment coordinates used by the first renderer.
+  static const mapMinCoordinate = -1.0;
+  static const mapMaxCoordinate = 1.0;
+
+  /// A small global gap keeps islands from touching even when their visual
+  /// footprints are smaller than the size-specific collision radii below.
+  static const minimumIslandSpacing = 0.20;
+
+  /// The default retry budget for a complete map generation attempt.
+  static const defaultMapGenerationAttempts = 64;
+
+  /// The retry budget for placing one symmetric pair during a map attempt.
+  static const defaultPairPlacementAttempts = 128;
 
   GameState initialState({
     GameConfiguration configuration = GameConfiguration.initial,
@@ -38,34 +54,94 @@ final class GameRules {
     return initialState(configuration: configuration, random: random);
   }
 
+  /// Generates a valid map or throws a [StateError] after the bounded retry
+  /// budget is exhausted.  Call [tryGenerateIslands] when a caller needs to
+  /// handle an impossible map as a nullable result instead.
   List<IslandState> generateIslands({
     GameConfiguration configuration = GameConfiguration.initial,
     math.Random? random,
+    int maxAttempts = defaultMapGenerationAttempts,
+    int? maxRetries,
+    int maxPairAttempts = defaultPairPlacementAttempts,
+    int? maxPairRetries,
   }) {
+    final islands = tryGenerateIslands(
+      configuration: configuration,
+      random: random,
+      maxAttempts: maxAttempts,
+      maxRetries: maxRetries,
+      maxPairAttempts: maxPairAttempts,
+      maxPairRetries: maxPairRetries,
+    );
+    if (islands == null) {
+      final attempts = maxRetries ?? maxAttempts;
+      final pairAttempts = maxPairRetries ?? maxPairAttempts;
+      throw StateError(
+        'Unable to generate a valid map after $attempts map attempts '
+        'and $pairAttempts pair attempts',
+      );
+    }
+    return islands;
+  }
+
+  /// Attempts to generate a valid map without ever retrying indefinitely.
+  ///
+  /// The two headquarters are fixed at the bottom-right and top-left corners.
+  /// Every neutral island is generated as a pair so its counterpart is the
+  /// exact point reflection around the screen center.  A null result means the
+  /// supplied retry budget could not produce a non-overlapping placement.
+  List<IslandState>? tryGenerateIslands({
+    GameConfiguration configuration = GameConfiguration.initial,
+    math.Random? random,
+    int maxAttempts = defaultMapGenerationAttempts,
+    int? maxRetries,
+    int maxPairAttempts = defaultPairPlacementAttempts,
+    int? maxPairRetries,
+  }) {
+    final attempts = maxRetries ?? maxAttempts;
+    final pairAttempts = maxPairRetries ?? maxPairAttempts;
+    if (attempts < 0) {
+      throw ArgumentError.value(
+        attempts,
+        'maxAttempts',
+        'must not be negative',
+      );
+    }
+    if (pairAttempts < 0) {
+      throw ArgumentError.value(
+        pairAttempts,
+        'maxPairAttempts',
+        'must not be negative',
+      );
+    }
+    if (attempts == 0 || pairAttempts == 0) {
+      return null;
+    }
+
     final source = random ?? math.Random();
     final neutralSizes = _neutralSizes(configuration.totalIslandCount);
-    return [
-      const IslandState(
-        id: 0,
-        position: IslandPosition(x: 1, y: 1),
-        faction: Faction.player,
-        size: IslandSize.headquarters,
-        currentForces: 100,
-        durability: 0,
-        capacity: 200,
-      ),
-      const IslandState(
-        id: 1,
-        position: IslandPosition(x: -1, y: -1),
-        faction: Faction.cpu,
-        size: IslandSize.headquarters,
-        currentForces: 100,
-        durability: 0,
-        capacity: 200,
-      ),
-      for (var id = 2; id < configuration.totalIslandCount; id++)
-        _neutralIsland(id: id, size: neutralSizes[id - 2], random: source),
-    ];
+    for (var mapAttempt = 0; mapAttempt < attempts; mapAttempt++) {
+      final islands = <IslandState>[_playerHeadquarters, _cpuHeadquarters];
+      var generated = true;
+      for (var pairIndex = 0; pairIndex < neutralSizes.length; pairIndex += 2) {
+        final pair = _tryPlaceNeutralPair(
+          firstId: pairIndex + 2,
+          size: neutralSizes[pairIndex],
+          existing: islands,
+          random: source,
+          maxAttempts: pairAttempts,
+        );
+        if (pair == null) {
+          generated = false;
+          break;
+        }
+        islands.addAll(pair);
+      }
+      if (generated) {
+        return List<IslandState>.unmodifiable(islands);
+      }
+    }
+    return null;
   }
 
   /// Returns whether a phase change is valid without mutating any state.
@@ -292,27 +368,121 @@ final class GameRules {
     );
   }
 
+  static const _playerHeadquarters = IslandState(
+    id: 0,
+    position: IslandPosition(x: 1, y: 1),
+    faction: Faction.player,
+    size: IslandSize.headquarters,
+    currentForces: 100,
+    durability: 0,
+    capacity: 200,
+  );
+
+  static const _cpuHeadquarters = IslandState(
+    id: 1,
+    position: IslandPosition(x: -1, y: -1),
+    faction: Faction.cpu,
+    size: IslandSize.headquarters,
+    currentForces: 100,
+    durability: 0,
+    capacity: 200,
+  );
+
+  /// Approximate normalized collision radius for the renderer's island
+  /// footprints.  The value is intentionally conservative so generated
+  /// centers cannot visually overlap at the expected widget sizes.
+  static double islandRadius(IslandSize size) {
+    return switch (size) {
+      IslandSize.small => 0.10,
+      IslandSize.medium => 0.14,
+      IslandSize.large => 0.18,
+      IslandSize.headquarters => 0.24,
+    };
+  }
+
+  static List<IslandState>? _tryPlaceNeutralPair({
+    required int firstId,
+    required IslandSize size,
+    required List<IslandState> existing,
+    required math.Random random,
+    required int maxAttempts,
+  }) {
+    final radius = islandRadius(size);
+    final minCoordinate = mapMinCoordinate + radius;
+    final coordinateRange = mapMaxCoordinate - radius - minCoordinate;
+    if (coordinateRange < 0) {
+      return null;
+    }
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      final firstPosition = IslandPosition(
+        x: minCoordinate + random.nextDouble() * coordinateRange,
+        y: minCoordinate + random.nextDouble() * coordinateRange,
+      );
+      final secondPosition = IslandPosition(
+        x: -firstPosition.x,
+        y: -firstPosition.y,
+      );
+      final first = _neutralIsland(
+        id: firstId,
+        size: size,
+        position: firstPosition,
+      );
+      final second = _neutralIsland(
+        id: firstId + 1,
+        size: size,
+        position: secondPosition,
+      );
+
+      if (_islandPairSeparated(first, second, existing)) {
+        return [first, second];
+      }
+    }
+    return null;
+  }
+
+  static bool _islandPairSeparated(
+    IslandState first,
+    IslandState second,
+    List<IslandState> existing,
+  ) {
+    if (!_islandPositionsSeparated(first, second)) {
+      return false;
+    }
+    for (final island in existing) {
+      if (!_islandPositionsSeparated(first, island) ||
+          !_islandPositionsSeparated(second, island)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _islandPositionsSeparated(IslandState first, IslandState second) {
+    final requiredDistance = math.max(
+      minimumIslandSpacing,
+      islandRadius(first.size) + islandRadius(second.size),
+    );
+    final deltaX = first.x - second.x;
+    final deltaY = first.y - second.y;
+    final distanceSquared = deltaX * deltaX + deltaY * deltaY;
+    return distanceSquared + 1e-12 >= requiredDistance * requiredDistance;
+  }
+
   static IslandState _neutralIsland({
     required int id,
     required IslandSize size,
-    required math.Random random,
+    required IslandPosition position,
   }) {
     return IslandState(
       id: id,
-      position: IslandPosition(
-        x: _randomCoordinate(random),
-        y: _randomCoordinate(random),
-      ),
+      position: position,
       faction: Faction.neutral,
       size: size,
       currentForces: 0,
       durability: size.neutralDurability ?? 0,
       capacity: size.capacity,
     );
-  }
-
-  static double _randomCoordinate(math.Random random) {
-    return random.nextBool() ? random.nextDouble() : random.nextDouble() - 1;
   }
 
   static List<IslandSize> _neutralSizes(int totalIslandCount) {

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -10,9 +10,9 @@ final class IslandMapViewport {
   /// A representative portrait viewport used by the regression tests.
   static const reference = IslandMapViewport(width: 390, height: 844);
 
-  /// The conservative default for callers that do not have layout constraints
-  /// yet.  Maps generated for this viewport also fit larger portrait screens.
-  static const minimumPortrait = IslandMapViewport(width: 320, height: 568);
+  /// The minimum axis envelope for supported portrait layouts.  Maps generated
+  /// for this viewport also fit every larger portrait screen.
+  static const minimumPortrait = IslandMapViewport(width: 320, height: 320);
 
   final double width;
   final double height;
@@ -547,19 +547,19 @@ final class GameRules {
     List<IslandState> existing,
     IslandMapViewport viewport,
   ) {
-    if (_islandRectsOverlap(first, second, viewport)) {
+    if (islandRectanglesOverlap(first, second, viewport)) {
       return false;
     }
     for (final island in existing) {
-      if (_islandRectsOverlap(first, island, viewport) ||
-          _islandRectsOverlap(second, island, viewport)) {
+      if (islandRectanglesOverlap(first, island, viewport) ||
+          islandRectanglesOverlap(second, island, viewport)) {
         return false;
       }
     }
     return true;
   }
 
-  static bool _islandRectsOverlap(
+  static bool islandRectanglesOverlap(
     IslandState first,
     IslandState second,
     IslandMapViewport viewport,

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -2,6 +2,73 @@ import 'dart:math' as math;
 
 import 'game_state.dart';
 
+/// The pixel viewport used to translate normalized [IslandPosition] values
+/// into the same alignment centers as the renderer.
+final class IslandMapViewport {
+  const IslandMapViewport({required this.width, required this.height});
+
+  /// A representative portrait viewport used by the regression tests.
+  static const reference = IslandMapViewport(width: 390, height: 844);
+
+  /// The conservative default for callers that do not have layout constraints
+  /// yet.  Maps generated for this viewport also fit larger portrait screens.
+  static const minimumPortrait = IslandMapViewport(width: 320, height: 568);
+
+  final double width;
+  final double height;
+
+  bool get isValid =>
+      width.isFinite && height.isFinite && width > 0 && height > 0;
+
+  IslandMapRect rectFor(IslandState island) {
+    return rectForPosition(island.position, island.size);
+  }
+
+  IslandMapRect rectForPosition(IslandPosition position, IslandSize size) {
+    final widgetSize = GameRules.islandWidgetSize(size);
+    // Flutter's Align lays out a child with
+    // `(parent - child) * (alignment + 1) / 2`; using the child size here is
+    // what makes this contract match the actual centers in lib/home.dart.
+    final left = (width - widgetSize) * (position.x + 1) / 2;
+    final top = (height - widgetSize) * (position.y + 1) / 2;
+    return IslandMapRect(
+      left: left,
+      top: top,
+      right: left + widgetSize,
+      bottom: top + widgetSize,
+    );
+  }
+}
+
+/// A renderer-independent rectangle for one island's square widget.
+final class IslandMapRect {
+  const IslandMapRect({
+    required this.left,
+    required this.top,
+    required this.right,
+    required this.bottom,
+  });
+
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  bool overlaps(IslandMapRect other) {
+    return left < other.right &&
+        other.left < right &&
+        top < other.bottom &&
+        other.top < bottom;
+  }
+
+  bool isWithin(IslandMapViewport viewport) {
+    return left >= 0 &&
+        top >= 0 &&
+        right <= viewport.width &&
+        bottom <= viewport.height;
+  }
+}
+
 /// Pure, deterministic game-state transitions.
 ///
 /// The class has no Riverpod, timer, or Flutter dependency.  Callers provide
@@ -20,9 +87,17 @@ final class GameRules {
   static const mapMinCoordinate = -1.0;
   static const mapMaxCoordinate = 1.0;
 
-  /// A small global gap keeps islands from touching even when their visual
-  /// footprints are smaller than the size-specific collision radii below.
-  static const minimumIslandSpacing = 0.20;
+  /// These dimensions are shared with [Home]'s `SizedBox` widgets.  Neutral
+  /// island variants currently use the same 50px square; the enum is retained
+  /// in the API so a future renderer can give each variant its own size.
+  static const headquartersWidgetSize = 100.0;
+  static const neutralWidgetSize = 50.0;
+
+  /// A layout-independent fallback for state creation before Flutter layout
+  /// constraints are available.  Callers with a real viewport should pass it
+  /// to [generateIslands] so collision and safe-area checks use exact pixels.
+  static const defaultMapViewport = IslandMapViewport.minimumPortrait;
+  static const referenceMapViewport = IslandMapViewport.reference;
 
   /// The default retry budget for a complete map generation attempt.
   static const defaultMapGenerationAttempts = 64;
@@ -30,15 +105,26 @@ final class GameRules {
   /// The retry budget for placing one symmetric pair during a map attempt.
   static const defaultPairPlacementAttempts = 128;
 
+  static double islandWidgetSize(IslandSize size) {
+    return size == IslandSize.headquarters
+        ? headquartersWidgetSize
+        : neutralWidgetSize;
+  }
+
   GameState initialState({
     GameConfiguration configuration = GameConfiguration.initial,
     math.Random? random,
+    IslandMapViewport viewport = defaultMapViewport,
   }) {
     return GameState(
       configuration: configuration,
       phase: GamePhase.configuration,
       elapsedMs: 0,
-      islands: generateIslands(configuration: configuration, random: random),
+      islands: generateIslands(
+        configuration: configuration,
+        random: random,
+        viewport: viewport,
+      ),
       selectedIslandId: null,
       movingForces: const <MovingForce>[],
       result: null,
@@ -50,8 +136,13 @@ final class GameRules {
   GameState createInitialState({
     GameConfiguration configuration = GameConfiguration.initial,
     math.Random? random,
+    IslandMapViewport viewport = defaultMapViewport,
   }) {
-    return initialState(configuration: configuration, random: random);
+    return initialState(
+      configuration: configuration,
+      random: random,
+      viewport: viewport,
+    );
   }
 
   /// Generates a valid map or throws a [StateError] after the bounded retry
@@ -60,6 +151,7 @@ final class GameRules {
   List<IslandState> generateIslands({
     GameConfiguration configuration = GameConfiguration.initial,
     math.Random? random,
+    IslandMapViewport viewport = defaultMapViewport,
     int maxAttempts = defaultMapGenerationAttempts,
     int? maxRetries,
     int maxPairAttempts = defaultPairPlacementAttempts,
@@ -68,6 +160,7 @@ final class GameRules {
     final islands = tryGenerateIslands(
       configuration: configuration,
       random: random,
+      viewport: viewport,
       maxAttempts: maxAttempts,
       maxRetries: maxRetries,
       maxPairAttempts: maxPairAttempts,
@@ -93,6 +186,7 @@ final class GameRules {
   List<IslandState>? tryGenerateIslands({
     GameConfiguration configuration = GameConfiguration.initial,
     math.Random? random,
+    IslandMapViewport viewport = defaultMapViewport,
     int maxAttempts = defaultMapGenerationAttempts,
     int? maxRetries,
     int maxPairAttempts = defaultPairPlacementAttempts,
@@ -117,6 +211,17 @@ final class GameRules {
     if (attempts == 0 || pairAttempts == 0) {
       return null;
     }
+    if (!viewport.isValid) {
+      throw ArgumentError.value(
+        viewport,
+        'viewport',
+        'must have positive dimensions',
+      );
+    }
+    if (viewport.width < headquartersWidgetSize ||
+        viewport.height < headquartersWidgetSize) {
+      return null;
+    }
 
     final source = random ?? math.Random();
     final neutralSizes = _neutralSizes(configuration.totalIslandCount);
@@ -129,6 +234,7 @@ final class GameRules {
           size: neutralSizes[pairIndex],
           existing: islands,
           random: source,
+          viewport: viewport,
           maxAttempts: pairAttempts,
         );
         if (pair == null) {
@@ -388,36 +494,30 @@ final class GameRules {
     capacity: 200,
   );
 
-  /// Approximate normalized collision radius for the renderer's island
-  /// footprints.  The value is intentionally conservative so generated
-  /// centers cannot visually overlap at the expected widget sizes.
-  static double islandRadius(IslandSize size) {
-    return switch (size) {
-      IslandSize.small => 0.10,
-      IslandSize.medium => 0.14,
-      IslandSize.large => 0.18,
-      IslandSize.headquarters => 0.24,
-    };
-  }
-
   static List<IslandState>? _tryPlaceNeutralPair({
     required int firstId,
     required IslandSize size,
     required List<IslandState> existing,
     required math.Random random,
+    required IslandMapViewport viewport,
     required int maxAttempts,
   }) {
-    final radius = islandRadius(size);
-    final minCoordinate = mapMinCoordinate + radius;
-    final coordinateRange = mapMaxCoordinate - radius - minCoordinate;
-    if (coordinateRange < 0) {
+    // Align itself keeps any child inside the viewport for every alignment in
+    // [-1, 1], so the normalized map bounds are also the safe-area bounds.
+    final minX = mapMinCoordinate;
+    final maxX = mapMaxCoordinate;
+    final minY = mapMinCoordinate;
+    final maxY = mapMaxCoordinate;
+    final xRange = maxX - minX;
+    final yRange = maxY - minY;
+    if (xRange < 0 || yRange < 0) {
       return null;
     }
 
     for (var attempt = 0; attempt < maxAttempts; attempt++) {
       final firstPosition = IslandPosition(
-        x: minCoordinate + random.nextDouble() * coordinateRange,
-        y: minCoordinate + random.nextDouble() * coordinateRange,
+        x: minX + random.nextDouble() * xRange,
+        y: minY + random.nextDouble() * yRange,
       );
       final secondPosition = IslandPosition(
         x: -firstPosition.x,
@@ -434,7 +534,7 @@ final class GameRules {
         position: secondPosition,
       );
 
-      if (_islandPairSeparated(first, second, existing)) {
+      if (_islandPairSeparated(first, second, existing, viewport)) {
         return [first, second];
       }
     }
@@ -445,28 +545,26 @@ final class GameRules {
     IslandState first,
     IslandState second,
     List<IslandState> existing,
+    IslandMapViewport viewport,
   ) {
-    if (!_islandPositionsSeparated(first, second)) {
+    if (_islandRectsOverlap(first, second, viewport)) {
       return false;
     }
     for (final island in existing) {
-      if (!_islandPositionsSeparated(first, island) ||
-          !_islandPositionsSeparated(second, island)) {
+      if (_islandRectsOverlap(first, island, viewport) ||
+          _islandRectsOverlap(second, island, viewport)) {
         return false;
       }
     }
     return true;
   }
 
-  static bool _islandPositionsSeparated(IslandState first, IslandState second) {
-    final requiredDistance = math.max(
-      minimumIslandSpacing,
-      islandRadius(first.size) + islandRadius(second.size),
-    );
-    final deltaX = first.x - second.x;
-    final deltaY = first.y - second.y;
-    final distanceSquared = deltaX * deltaX + deltaY * deltaY;
-    return distanceSquared + 1e-12 >= requiredDistance * requiredDistance;
+  static bool _islandRectsOverlap(
+    IslandState first,
+    IslandState second,
+    IslandMapViewport viewport,
+  ) {
+    return viewport.rectFor(first).overlaps(viewport.rectFor(second));
   }
 
   static IslandState _neutralIsland({

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'game/game_controller.dart';
+import 'game/game_rules.dart';
 import 'game/game_state.dart';
 
 class Home extends ConsumerWidget {
@@ -30,8 +31,8 @@ class Home extends ConsumerWidget {
               Align(
                 alignment: Alignment(base.x, base.y),
                 child: SizedBox(
-                  height: base.id == 0 || base.id == 1 ? 100 : 50,
-                  width: base.id == 0 || base.id == 1 ? 100 : 50,
+                  height: GameRules.islandWidgetSize(base.size),
+                  width: GameRules.islandWidgetSize(base.size),
                   child: Base(
                     base: base,
                     onPressed: () => controller.tapBase(base.id),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -6,8 +6,35 @@ import 'game/game_controller.dart';
 import 'game/game_rules.dart';
 import 'game/game_state.dart';
 
-class Home extends ConsumerWidget {
+class Home extends StatelessWidget {
   const Home({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final viewport = IslandMapViewport(
+              width: constraints.maxWidth,
+              height: constraints.maxHeight,
+            );
+            return ProviderScope(
+              overrides: [
+                mapViewportProvider.overrideWithValue(viewport),
+                gameControllerProvider.overrideWith(GameController.new),
+              ],
+              child: const _GameSurface(),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _GameSurface extends ConsumerWidget {
+  const _GameSurface();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -20,55 +47,53 @@ class Home extends ConsumerWidget {
           controller.startGame();
         }
       },
-      child: Scaffold(
-        body: Stack(
-          children: [
-            // * 背景
-            Container(height: double.infinity, color: Colors.blue),
+      child: Stack(
+        children: [
+          // * 背景
+          Container(height: double.infinity, color: Colors.blue),
 
-            // * 拠点(自動生成)
-            for (final base in state.bases) ...[
-              Align(
-                alignment: Alignment(base.x, base.y),
-                child: SizedBox(
-                  height: GameRules.islandWidgetSize(base.size),
-                  width: GameRules.islandWidgetSize(base.size),
-                  child: Base(
-                    base: base,
-                    onPressed: () => controller.tapBase(base.id),
-                  ),
+          // * 拠点(自動生成)
+          for (final base in state.bases) ...[
+            Align(
+              alignment: Alignment(base.x, base.y),
+              child: SizedBox(
+                height: GameRules.islandWidgetSize(base.size),
+                width: GameRules.islandWidgetSize(base.size),
+                child: Base(
+                  base: base,
+                  onPressed: () => controller.tapBase(base.id),
                 ),
               ),
-            ],
-
-            // * Tank
-            state.movement != null
-                ? Align(
-                    alignment: Alignment(state.movement!.x, state.movement!.y),
-                    child: Container(
-                      key: const ValueKey('tank'),
-                      color: Colors.red,
-                      height: 30,
-                      width: 30,
-                      child: Center(
-                        child: Text(state.movement!.scale.toString()),
-                      ),
-                    ),
-                  )
-                : const SizedBox(),
-
-            // * Ready画面
-            state.phase == GamePhase.ready
-                ? const Align(
-                    alignment: Alignment(0, -0.2),
-                    child: Text(
-                      'T A P  T O  P L A Y',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  )
-                : const SizedBox(),
+            ),
           ],
-        ),
+
+          // * Tank
+          state.movement != null
+              ? Align(
+                  alignment: Alignment(state.movement!.x, state.movement!.y),
+                  child: Container(
+                    key: const ValueKey('tank'),
+                    color: Colors.red,
+                    height: 30,
+                    width: 30,
+                    child: Center(
+                      child: Text(state.movement!.scale.toString()),
+                    ),
+                  ),
+                )
+              : const SizedBox(),
+
+          // * Ready画面
+          state.phase == GamePhase.ready
+              ? const Align(
+                  alignment: Alignment(0, -0.2),
+                  child: Text(
+                    'T A P  T O  P L A Y',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                )
+              : const SizedBox(),
+        ],
       ),
     );
   }

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -75,6 +75,24 @@ void main() {
     );
   });
 
+  test('uses an externally configured island count on initial build', () {
+    final configuredContainer = ProviderContainer(
+      overrides: [
+        gameConfigurationProvider.overrideWithValue(
+          GameConfiguration(totalIslandCount: 8),
+        ),
+        gameLoopProvider.overrideWithValue(ManualGameLoop()),
+        randomProvider.overrideWithValue(Random(1)),
+      ],
+    );
+    addTearDown(configuredContainer.dispose);
+
+    final state = configuredContainer.read(gameControllerProvider);
+
+    expect(state.configuration.totalIslandCount, 8);
+    expect(state.islands, hasLength(8));
+  });
+
   test('starts the game and loop only once', () {
     final controller = container.read(gameControllerProvider.notifier);
 

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -148,19 +148,20 @@ void main() {
 
   test('generated maps stay in viewport bounds and do not overlap', () {
     const viewports = <IslandMapViewport>[
+      IslandMapViewport(width: 320, height: 320),
+      IslandMapViewport(width: 320, height: 480),
       IslandMapViewport(width: 320, height: 568),
       IslandMapViewport(width: 390, height: 844),
       IslandMapViewport(width: 430, height: 932),
     ];
-    for (final viewport in viewports) {
-      for (final total in GameConfiguration.allowedIslandCounts) {
-        for (var seed = 0; seed < 20; seed++) {
-          final islands = rules.generateIslands(
-            configuration: GameConfiguration(totalIslandCount: total),
-            random: Random(seed),
-            viewport: viewport,
-          );
+    for (final total in GameConfiguration.allowedIslandCounts) {
+      for (var seed = 0; seed < 20; seed++) {
+        final islands = rules.generateIslands(
+          configuration: GameConfiguration(totalIslandCount: total),
+          random: Random(seed),
+        );
 
+        for (final viewport in viewports) {
           for (final island in islands) {
             expect(island.x, inInclusiveRange(-1.0, 1.0));
             expect(island.y, inInclusiveRange(-1.0, 1.0));
@@ -236,6 +237,48 @@ void main() {
       );
     },
   );
+
+  test('default envelope rejects the short-screen symmetric overlap case', () {
+    const viewport = GameRules.defaultMapViewport;
+    const first = IslandState(
+      id: 2,
+      position: IslandPosition(x: 0, y: 0.105),
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+      capacity: 50,
+    );
+    const counterpart = IslandState(
+      id: 3,
+      position: IslandPosition(x: 0, y: -0.105),
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+      capacity: 50,
+    );
+
+    expect(
+      GameRules.islandRectanglesOverlap(first, counterpart, viewport),
+      isTrue,
+    );
+    final islands = rules.generateIslands(
+      configuration: GameConfiguration(totalIslandCount: 6),
+      random: Random(20),
+    );
+    final rectangles = [for (final island in islands) viewport.rectFor(island)];
+    for (var firstIndex = 0; firstIndex < rectangles.length; firstIndex++) {
+      for (
+        var secondIndex = firstIndex + 1;
+        secondIndex < rectangles.length;
+        secondIndex++
+      ) {
+        expect(
+          rectangles[firstIndex].overlaps(rectangles[secondIndex]),
+          isFalse,
+        );
+      }
+    }
+  });
 
   test('map generation is reproducible for a seed and varies across seeds', () {
     final first = rules.generateIslands(random: Random(123));

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -108,6 +108,109 @@ void main() {
     },
   );
 
+  test('generated maps keep fixed headquarters and pair neutral islands', () {
+    const expectedSizes = <int, Map<IslandSize, int>>{
+      6: {IslandSize.small: 2, IslandSize.medium: 2},
+      8: {IslandSize.small: 2, IslandSize.medium: 2, IslandSize.large: 2},
+      10: {IslandSize.small: 4, IslandSize.medium: 2, IslandSize.large: 2},
+      12: {IslandSize.small: 4, IslandSize.medium: 4, IslandSize.large: 2},
+    };
+
+    for (final entry in expectedSizes.entries) {
+      final islands = rules.generateIslands(
+        configuration: GameConfiguration(totalIslandCount: entry.key),
+        random: Random(entry.key),
+      );
+      expect(islands, hasLength(entry.key));
+      expect(islands[0].position, const IslandPosition(x: 1, y: 1));
+      expect(islands[0].faction, Faction.player);
+      expect(islands[0].currentForces, 100);
+      expect(islands[0].capacity, 200);
+      expect(islands[1].position, const IslandPosition(x: -1, y: -1));
+      expect(islands[1].faction, Faction.cpu);
+      expect(islands[1].currentForces, 100);
+      expect(islands[1].capacity, 200);
+
+      final counts = <IslandSize, int>{};
+      for (var index = 2; index < islands.length; index += 2) {
+        final first = islands[index];
+        final second = islands[index + 1];
+        counts[first.size] = (counts[first.size] ?? 0) + 2;
+        expect(second.size, first.size);
+        expect(second.position.x, closeTo(-first.position.x, 1e-12));
+        expect(second.position.y, closeTo(-first.position.y, 1e-12));
+        expect(second.durability, first.durability);
+        expect(second.capacity, first.capacity);
+      }
+      expect(counts, entry.value);
+    }
+  });
+
+  test('generated maps stay in bounds and do not overlap', () {
+    for (final total in GameConfiguration.allowedIslandCounts) {
+      for (var seed = 0; seed < 20; seed++) {
+        final islands = rules.generateIslands(
+          configuration: GameConfiguration(totalIslandCount: total),
+          random: Random(seed),
+        );
+
+        for (final island in islands) {
+          expect(island.x, inInclusiveRange(-1.0, 1.0));
+          expect(island.y, inInclusiveRange(-1.0, 1.0));
+        }
+        for (var firstIndex = 0; firstIndex < islands.length; firstIndex++) {
+          for (
+            var secondIndex = firstIndex + 1;
+            secondIndex < islands.length;
+            secondIndex++
+          ) {
+            final first = islands[firstIndex];
+            final second = islands[secondIndex];
+            final distance = sqrt(
+              pow(first.x - second.x, 2) + pow(first.y - second.y, 2),
+            );
+            final requiredDistance = max(
+              GameRules.minimumIslandSpacing,
+              GameRules.islandRadius(first.size) +
+                  GameRules.islandRadius(second.size),
+            );
+            expect(
+              distance,
+              greaterThanOrEqualTo(requiredDistance - 1e-12),
+              reason: 'islands ${first.id} and ${second.id} overlap',
+            );
+          }
+        }
+      }
+    }
+  });
+
+  test('map generation is reproducible for a seed and varies across seeds', () {
+    final first = rules.generateIslands(random: Random(123));
+    final second = rules.generateIslands(random: Random(123));
+    final different = rules.generateIslands(random: Random(124));
+
+    expect(first, second);
+    expect(
+      first.skip(2).map((island) => island.position),
+      isNot(orderedEquals(different.skip(2).map((island) => island.position))),
+    );
+  });
+
+  test(
+    'map generation returns a bounded failure when attempts are exhausted',
+    () {
+      expect(
+        rules.tryGenerateIslands(random: Random(1), maxAttempts: 0),
+        isNull,
+      );
+      expect(
+        () => rules.generateIslands(random: Random(1), maxAttempts: 0),
+        throwsA(isA<StateError>()),
+      );
+    },
+  );
+
   test('state holds multiple typed moving forces immutably', () {
     const forces = [
       MovingForce(

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -415,6 +415,30 @@ void main() {
     );
   });
 
+  test(
+    'returns a bounded failure when fixed headquarters cannot be separated',
+    () {
+      const viewport = IslandMapViewport(width: 180, height: 180);
+
+      expect(
+        rules.tryGenerateIslands(
+          configuration: GameConfiguration(totalIslandCount: 6),
+          random: Random(1),
+          viewport: viewport,
+        ),
+        isNull,
+      );
+      expect(
+        () => rules.generateIslands(
+          configuration: GameConfiguration(totalIslandCount: 6),
+          random: Random(1),
+          viewport: viewport,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    },
+  );
+
   test('countdown self-transitions preserve remaining time', () {
     final initial = rules.initialState(random: Random(5));
     final countdown = rules.startCountdown(initial, durationMs: 1000);

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -146,44 +146,96 @@ void main() {
     }
   });
 
-  test('generated maps stay in bounds and do not overlap', () {
-    for (final total in GameConfiguration.allowedIslandCounts) {
-      for (var seed = 0; seed < 20; seed++) {
-        final islands = rules.generateIslands(
-          configuration: GameConfiguration(totalIslandCount: total),
-          random: Random(seed),
-        );
+  test('generated maps stay in viewport bounds and do not overlap', () {
+    const viewports = <IslandMapViewport>[
+      IslandMapViewport(width: 320, height: 568),
+      IslandMapViewport(width: 390, height: 844),
+      IslandMapViewport(width: 430, height: 932),
+    ];
+    for (final viewport in viewports) {
+      for (final total in GameConfiguration.allowedIslandCounts) {
+        for (var seed = 0; seed < 20; seed++) {
+          final islands = rules.generateIslands(
+            configuration: GameConfiguration(totalIslandCount: total),
+            random: Random(seed),
+            viewport: viewport,
+          );
 
-        for (final island in islands) {
-          expect(island.x, inInclusiveRange(-1.0, 1.0));
-          expect(island.y, inInclusiveRange(-1.0, 1.0));
-        }
-        for (var firstIndex = 0; firstIndex < islands.length; firstIndex++) {
-          for (
-            var secondIndex = firstIndex + 1;
-            secondIndex < islands.length;
-            secondIndex++
-          ) {
-            final first = islands[firstIndex];
-            final second = islands[secondIndex];
-            final distance = sqrt(
-              pow(first.x - second.x, 2) + pow(first.y - second.y, 2),
-            );
-            final requiredDistance = max(
-              GameRules.minimumIslandSpacing,
-              GameRules.islandRadius(first.size) +
-                  GameRules.islandRadius(second.size),
-            );
+          for (final island in islands) {
+            expect(island.x, inInclusiveRange(-1.0, 1.0));
+            expect(island.y, inInclusiveRange(-1.0, 1.0));
+          }
+          final rectangles = [
+            for (final island in islands) viewport.rectFor(island),
+          ];
+          for (var index = 0; index < rectangles.length; index++) {
             expect(
-              distance,
-              greaterThanOrEqualTo(requiredDistance - 1e-12),
-              reason: 'islands ${first.id} and ${second.id} overlap',
+              rectangles[index].isWithin(viewport),
+              isTrue,
+              reason: 'island ${islands[index].id} is outside the safe area',
             );
+          }
+          for (
+            var firstIndex = 0;
+            firstIndex < rectangles.length;
+            firstIndex++
+          ) {
+            for (
+              var secondIndex = firstIndex + 1;
+              secondIndex < rectangles.length;
+              secondIndex++
+            ) {
+              expect(
+                rectangles[firstIndex].overlaps(rectangles[secondIndex]),
+                isFalse,
+                reason:
+                    'islands ${islands[firstIndex].id} and '
+                    '${islands[secondIndex].id} overlap',
+              );
+            }
           }
         }
       }
     }
   });
+
+  test(
+    'viewport rectangles catch the tall-screen headquarters overlap case',
+    () {
+      const viewport = IslandMapViewport(width: 390, height: 844);
+      const headquarters = IslandState(
+        id: 0,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 100,
+        capacity: 200,
+      );
+      const small = IslandState(
+        id: 2,
+        position: IslandPosition(x: 0.66, y: 0.89),
+        faction: Faction.neutral,
+        size: IslandSize.small,
+        durability: 10,
+        capacity: 50,
+      );
+
+      final headquartersRect = viewport.rectFor(headquarters);
+      final smallRect = viewport.rectFor(small);
+      expect(headquartersRect.left, closeTo(290, 1e-12));
+      expect(headquartersRect.top, closeTo(744, 1e-12));
+      expect(smallRect.left, closeTo(282.2, 1e-12));
+      expect(smallRect.top, closeTo(750.33, 1e-12));
+      expect(headquartersRect.overlaps(smallRect), isTrue);
+      expect(
+        sqrt(
+          pow(headquarters.x - small.x, 2) + pow(headquarters.y - small.y, 2),
+        ),
+        greaterThan(0.34),
+        reason: 'the old normalized-radius check would incorrectly accept this',
+      );
+    },
+  );
 
   test('map generation is reproducible for a seed and varies across seeds', () {
     final first = rules.generateIslands(random: Random(123));
@@ -207,6 +259,13 @@ void main() {
       expect(
         () => rules.generateIslands(random: Random(1), maxAttempts: 0),
         throwsA(isA<StateError>()),
+      );
+      expect(
+        rules.tryGenerateIslands(
+          random: Random(1),
+          viewport: const IslandMapViewport(width: 80, height: 80),
+        ),
+        isNull,
       );
     },
   );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_loop.dart';
 import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/game/game_state.dart';
 import 'package:conquest/home.dart';
 import 'package:conquest/main.dart';
 import 'package:flutter/material.dart';
@@ -131,5 +132,27 @@ void main() {
     await tester.pumpWidget(ProviderScope(child: const MyApp()));
 
     expect(find.byType(ElevatedButton), findsNothing);
+  });
+
+  testWidgets('keeps the controller operable after the viewport changes', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(320, 500));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+
+    await tester.tap(find.text('T A P  T O  P L A Y'));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('tank')), findsNothing);
+
+    await tester.binding.setSurfaceSize(const Size(321, 500));
+    await tester.pump();
+
+    await tester.tap(find.text('T A P  T O  P L A Y'));
+    await tester.pump();
+
+    final button = tester.element(find.byType(ElevatedButton).first);
+    final container = ProviderScope.containerOf(button);
+    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_loop.dart';
+import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/home.dart';
 import 'package:conquest/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -59,5 +61,75 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const ValueKey('tank')), findsNothing);
+  });
+
+  testWidgets('keeps headquarters inside the SafeArea insets', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(320, 500));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [randomProvider.overrideWithValue(Random(1))],
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(320, 500),
+              padding: EdgeInsets.only(top: 24, bottom: 16),
+            ),
+            child: const Home(),
+          ),
+        ),
+      ),
+    );
+
+    final buttons = find.byType(ElevatedButton);
+    expect(buttons, findsNWidgets(10));
+    expect(tester.getTopLeft(buttons.at(1)).dy, closeTo(24, 1e-6));
+    expect(tester.getBottomRight(buttons.at(0)).dy, closeTo(484, 1e-6));
+  });
+
+  testWidgets('generates using the actual sub-320 layout constraints', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(280, 500));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [randomProvider.overrideWithValue(Random(1))],
+        child: const MyApp(),
+      ),
+    );
+
+    final button = tester.element(find.byType(ElevatedButton).first);
+    final container = ProviderScope.containerOf(button);
+    final state = container.read(gameControllerProvider);
+    const viewport = IslandMapViewport(width: 280, height: 500);
+
+    expect(state.islands, hasLength(10));
+    expect(
+      state.islands,
+      const GameRules().generateIslands(random: Random(1), viewport: viewport),
+    );
+    final rectangles = [
+      for (final island in state.islands) viewport.rectFor(island),
+    ];
+    for (final rectangle in rectangles) {
+      expect(rectangle.isWithin(viewport), isTrue);
+    }
+    for (var first = 0; first < rectangles.length; first++) {
+      for (var second = first + 1; second < rectangles.length; second++) {
+        expect(rectangles[first].overlaps(rectangles[second]), isFalse);
+      }
+    }
+  });
+
+  testWidgets('fails closed when the actual viewport cannot fit headquarters', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(180, 180));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(ProviderScope(child: const MyApp()));
+
+    expect(find.byType(ElevatedButton), findsNothing);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -134,6 +134,98 @@ void main() {
     expect(find.byType(ElevatedButton), findsNothing);
   });
 
+  testWidgets(
+    'preserves the selected island count in configuration on resize',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(320, 500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [randomProvider.overrideWithValue(Random(1))],
+          child: const MyApp(),
+        ),
+      );
+
+      final beforeButton = tester.element(find.byType(ElevatedButton).first);
+      final beforeContainer = ProviderScope.containerOf(beforeButton);
+      final controller = beforeContainer.read(gameControllerProvider.notifier);
+      controller.selectIslandCount(6);
+      await tester.pump();
+
+      final before = beforeContainer.read(gameControllerProvider);
+      expect(before.phase, GamePhase.configuration);
+      expect(before.configuration.totalIslandCount, 6);
+      expect(before.islands, hasLength(6));
+
+      await tester.binding.setSurfaceSize(const Size(321, 500));
+      await tester.pump();
+
+      final afterButton = tester.element(find.byType(ElevatedButton).first);
+      final afterContainer = ProviderScope.containerOf(afterButton);
+      final after = afterContainer.read(gameControllerProvider);
+      expect(after.phase, GamePhase.configuration);
+      expect(after.configuration.totalIslandCount, 6);
+      expect(after.islands, hasLength(6));
+    },
+  );
+
+  testWidgets(
+    'preserves a selected island count during an in-progress resize',
+    (tester) async {
+      final loop = ManualWidgetGameLoop();
+      await tester.binding.setSurfaceSize(const Size(320, 500));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gameLoopProvider.overrideWithValue(loop),
+            randomProvider.overrideWithValue(Random(1)),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      final beforeButton = tester.element(find.byType(ElevatedButton).first);
+      final beforeContainer = ProviderScope.containerOf(beforeButton);
+      final controller = beforeContainer.read(gameControllerProvider.notifier);
+      controller.selectIslandCount(6);
+      await tester.pump();
+      controller.startGame();
+      controller.tapBase(0);
+      controller.tapBase(1);
+      loop.tick();
+      await tester.pump();
+
+      final before = beforeContainer.read(gameControllerProvider);
+      expect(before.phase, GamePhase.playing);
+      expect(before.configuration.totalIslandCount, 6);
+      expect(before.islands, hasLength(6));
+      expect(before.elapsedMs, greaterThan(0));
+      expect(before.movingForces, isNotEmpty);
+      expect(before.selectedIslandId, 0);
+
+      await tester.binding.setSurfaceSize(const Size(321, 500));
+      await tester.pump();
+
+      final afterButton = tester.element(find.byType(ElevatedButton).first);
+      final afterContainer = ProviderScope.containerOf(afterButton);
+      final after = afterContainer.read(gameControllerProvider);
+      expect(after.phase, GamePhase.playing);
+      expect(after.configuration.totalIslandCount, 6);
+      expect(after.islands, hasLength(6));
+      expect(after.elapsedMs, before.elapsedMs);
+      expect(after.movingForces, before.movingForces);
+      expect(after.selectedIslandId, before.selectedIslandId);
+      expect(loop.isRunning, isTrue);
+
+      loop.tick();
+      await tester.pump();
+      final continued = afterContainer.read(gameControllerProvider);
+      expect(continued.elapsedMs, greaterThan(after.elapsedMs));
+      expect(continued.movingForces.first.progress, greaterThan(0));
+    },
+  );
+
   testWidgets('preserves an in-progress game after the viewport changes', (
     tester,
   ) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -134,25 +134,53 @@ void main() {
     expect(find.byType(ElevatedButton), findsNothing);
   });
 
-  testWidgets('keeps the controller operable after the viewport changes', (
+  testWidgets('preserves an in-progress game after the viewport changes', (
     tester,
   ) async {
+    final loop = ManualWidgetGameLoop();
     await tester.binding.setSurfaceSize(const Size(320, 500));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
 
     await tester.tap(find.text('T A P  T O  P L A Y'));
     await tester.pump();
-    expect(find.byKey(const ValueKey('tank')), findsNothing);
+    await tester.tap(find.byType(ElevatedButton).at(0));
+    await tester.tap(find.byType(ElevatedButton).at(1));
+    loop.tick();
+    await tester.pump();
+
+    final beforeButton = tester.element(find.byType(ElevatedButton).first);
+    final beforeContainer = ProviderScope.containerOf(beforeButton);
+    final before = beforeContainer.read(gameControllerProvider);
+    expect(before.phase, GamePhase.playing);
+    expect(before.elapsedMs, greaterThan(0));
+    expect(before.movingForces, isNotEmpty);
 
     await tester.binding.setSurfaceSize(const Size(321, 500));
     await tester.pump();
 
-    await tester.tap(find.text('T A P  T O  P L A Y'));
-    await tester.pump();
+    final afterButton = tester.element(find.byType(ElevatedButton).first);
+    final afterContainer = ProviderScope.containerOf(afterButton);
+    final after = afterContainer.read(gameControllerProvider);
+    expect(after.phase, GamePhase.playing);
+    expect(after.elapsedMs, before.elapsedMs);
+    expect(after.islands, before.islands);
+    expect(after.selectedIslandId, before.selectedIslandId);
+    expect(after.movingForces, before.movingForces);
+    expect(loop.isRunning, isTrue);
 
-    final button = tester.element(find.byType(ElevatedButton).first);
-    final container = ProviderScope.containerOf(button);
-    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
+    loop.tick();
+    await tester.pump();
+    final continued = afterContainer.read(gameControllerProvider);
+    expect(continued.elapsedMs, greaterThan(after.elapsedMs));
+    expect(continued.movingForces.first.progress, greaterThan(0));
   });
 }


### PR DESCRIPTION
## 概要

合計島数6・8・10・12に対応し、プレイヤーとCPUに公平な点対称ランダムマップを生成できるようにします。固定シードで再現可能で、島の画面外配置と視覚的な重なりをピクセル矩形で防止します。

## 背景・目的

Issue #7 で定義された島数・本陣・中立島構成をゲームルールへ実装し、試合ごとに安全で再現可能な初期マップを生成することが目的です。

## 対応内容

- 合計島数6・8・10・12と初期値10に対応
- プレイヤー本陣を右下、CPU本陣を左上へ固定し、兵力100・上限200で生成
- 中立島をサイズ・耐久力・上限が一致する点対称ペアとして生成
- Flutterの `Align` と同じ座標変換によるviewport矩形で境界・重なりを判定
- 乱数シード注入APIと、回数上限付きのnullable/exception生成APIを提供
- 島Widgetサイズをゲームルールと描画で共有
- 各設定、複数seed、複数portrait viewport、再現性、失敗上限の回帰テストを追加

## 主な設計判断

- 正規化座標上の距離では実際のWidget矩形の重なりを見落とすため、viewportサイズと島Widgetサイズから描画時の矩形を算出して判定します。
- viewport未確定時は最小portrait envelope（320x320）で生成し、より大きなportrait画面でも安全な配置を維持します。
- 無限ループを避けるため、マップ全体と各ペアの試行回数を個別に制限し、失敗を `null` または `StateError` として返します。

## 受け入れ条件との対応

- [x] 4種類の島数設定から正しい総数とサイズ構成を生成: `GameRules._neutralSizes` と設定別テスト
- [x] 初期設定では合計10島を生成: `GameConfiguration.initial` を使う生成APIと既存/追加テスト
- [x] 本陣の位置、陣営、初期兵力、上限が仕様と一致: 固定本陣定義と回帰テスト
- [x] すべての中立島に点対称の対応島が存在: ペア単位生成と対称性テスト
- [x] 対応する島のサイズ、耐久力、上限が一致: 同一サイズのペア生成と値のテスト
- [x] 島同士が視覚的に重ならず、安全領域内へ配置: `IslandMapViewport` / `IslandMapRect` と複数viewport・seedテスト
- [x] 同じシードでは同じマップ、異なるシードでは異なる配置: seed再現性テスト
- [x] 生成失敗時に無限ループせず安全に失敗を返す: 試行上限と失敗テスト
- [x] `fvm flutter analyze` と `fvm flutter test` が成功

## 検証

- `fvm dart format --output=none --set-exit-if-changed lib/game/game_controller.dart lib/game/game_rules.dart lib/home.dart test/game_controller_test.dart test/game_rules_test.dart test/widget_test.dart`: 成功
- `git diff --check origin/main...HEAD`: 成功
- `fvm flutter analyze`: 成功
- `fvm flutter test`: 成功（36 tests）

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `5ce47f5ade602d1e99ca14e0b6e810341e8cf280`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `7b7986876bea683a7bd1410010eb3a5da15e0baa`、fix HEAD: `5ce47f5ade602d1e99ca14e0b6e810341e8cf280`）
- Required checks: 対象なし

## 残存リスク

実端末viewportでの視覚確認とplatform buildは承認済みIssue/planの必須検証外のため未実施です。SafeArea inset、180x180のfail-closed、280x500から430x932までのportrait viewport、mount後resize時のstate/loop保持を自動テストしています。固定縦向き契約外の極端な動的縮小時における進行中マップの再投影UXは未定義です。

Closes #7