### PR TITLE
出兵ルールと複数部隊の距離比例移動を実装

### DIFF
--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -190,15 +190,26 @@ class GameController extends _$GameController {
     return nextState;
   }
 
-  /// Selects a player island and creates (or retargets the legacy first)
-  /// moving force.  The state itself supports any number of forces; retaining
-  /// the first-force retarget behavior keeps the PR #3 interaction intact.
+  /// Selects a player island or dispatches a new force to the tapped island.
+  /// Every successful dispatch is appended to the in-flight force list so an
+  /// earlier troop cannot be retargeted or cancelled.
   void tapBase(int baseId) {
     if (_disposed || state.phase != GamePhase.playing) {
       return;
     }
 
     final selectedIslandId = state.selectedIslandId;
+    final selectedSource = selectedIslandId == null
+        ? null
+        : _findIsland(selectedIslandId);
+    if (selectedIslandId != null &&
+        (selectedSource == null ||
+            selectedSource.faction != Faction.player ||
+            selectedSource.currentForces <= 1)) {
+      state = state.clearSelection();
+      return;
+    }
+
     final tappedIsland = _findIsland(baseId);
     if (tappedIsland == null) {
       return;
@@ -218,14 +229,7 @@ class GameController extends _$GameController {
       return;
     }
 
-    final source = _findIsland(selectedIslandId);
-    if (source == null ||
-        source.faction != Faction.player ||
-        source.currentForces <= 1) {
-      state = state.clearSelection();
-      return;
-    }
-
+    final source = selectedSource!;
     final strength = source.currentForces ~/ 2;
     if (strength <= 0) {
       state = state.clearSelection();
@@ -238,31 +242,20 @@ class GameController extends _$GameController {
       currentForces: source.currentForces - strength,
     );
 
-    final existingIndex = state.movingForces.indexWhere(
-      (force) => force.sourceIslandId == source.id,
-    );
     final movingForces = [...state.movingForces];
     final nextForce = _rules.createMovingForce(
-      id: existingIndex >= 0
-          ? movingForces[existingIndex].id
-          : _nextMovingForceId,
+      id: _nextMovingForceId,
       faction: Faction.player,
       source: source,
       destination: tappedIsland,
       strength: strength,
       departureTimeMs: state.elapsedMs,
     );
-    if (existingIndex >= 0) {
-      movingForces[existingIndex] = nextForce;
-    } else {
-      movingForces.add(nextForce);
-    }
+    movingForces.add(nextForce);
 
-    state = state.copyWith(
-      islands: islands,
-      movingForces: movingForces,
-      selectedIslandId: baseId == source.id ? null : selectedIslandId,
-    );
+    state = state
+        .copyWith(islands: islands, movingForces: movingForces)
+        .clearSelection();
   }
 
   void _tick() {

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -250,6 +250,7 @@ class GameController extends _$GameController {
       destination: tappedIsland,
       strength: strength,
       departureTimeMs: state.elapsedMs,
+      viewport: ref.read(mapViewportProvider),
     );
     movingForces.add(nextForce);
 

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -394,12 +394,31 @@ final class GameRules {
       );
     }
 
-    if (state.phase != GamePhase.playing || deltaMs == 0) {
+    if (state.phase != GamePhase.playing) {
       return state;
     }
 
     final elapsedMs = state.elapsedMs + deltaMs;
     var islands = [...state.islands];
+
+    // Validate an existing selection before applying resource ticks.  A
+    // source that was already exhausted or lost before this tick must not be
+    // revived by the same tick's regeneration.
+    final selectedIslandId = state.selectedIslandId;
+    IslandState? selectedAtStart;
+    if (selectedIslandId != null) {
+      for (final island in islands) {
+        if (island.id == selectedIslandId) {
+          selectedAtStart = island;
+          break;
+        }
+      }
+    }
+    final selectionInvalidAtStart =
+        selectedIslandId != null &&
+        (selectedAtStart == null ||
+            selectedAtStart.faction != Faction.player ||
+            selectedAtStart.currentForces <= 1);
 
     // Resource ticks are represented here as a deterministic time boundary;
     // concrete ownership/combat rules can later replace this helper without
@@ -417,8 +436,14 @@ final class GameRules {
     final remainingForces = <MovingForce>[];
     for (final force in state.movingForces) {
       final duration = math.max(1, force.durationMs);
-      final nextProgress = math.min(1.0, force.progress + deltaMs / duration);
-      if (nextProgress >= 1.0) {
+      final elapsedSinceDeparture = elapsedMs - force.departureTimeMs;
+      final nextProgress = elapsedSinceDeparture <= 0
+          ? 0.0
+          : math.min(1.0, elapsedSinceDeparture / duration);
+      final atArrivalBoundary =
+          elapsedMs >= force.arrivalTimeMs &&
+          elapsedMs >= force.departureTimeMs;
+      if (nextProgress >= 1.0 || atArrivalBoundary) {
         final targetIndex = islands.indexWhere(
           (island) => island.id == force.destinationIslandId,
         );
@@ -467,29 +492,25 @@ final class GameRules {
     );
 
     // A selected source remains active while the player is choosing a
-    // destination.  Only clear it after an existing dispatch has completed,
-    // or when the source can no longer dispatch under the current rules.
-    final selectedIsland = nextState.selectedIslandId == null
-        ? null
-        : nextState.islands.firstWhere(
-            (island) => island.id == nextState.selectedIslandId,
-            orElse: () => const IslandState(
-              id: -1,
-              position: IslandPosition(x: 0, y: 0),
-              faction: Faction.neutral,
-            ),
-          );
+    // destination.  Clear it only when the source can no longer dispatch
+    // under the current rules; an unrelated troop arrival must not affect it.
+    final nextSelectedIslandId = nextState.selectedIslandId;
+    if (nextSelectedIslandId == null) {
+      return nextState;
+    }
+    IslandState? selectedIsland;
+    for (final island in nextState.islands) {
+      if (island.id == nextSelectedIslandId) {
+        selectedIsland = island;
+        break;
+      }
+    }
     final selectionInvalid =
-        nextState.selectedIslandId != null &&
-        (selectedIsland == null ||
-            selectedIsland.id == -1 ||
-            selectedIsland.faction != Faction.player ||
-            selectedIsland.currentForces <= 1);
-    final dispatchCompleted =
-        state.movingForces.isNotEmpty && remainingForces.isEmpty;
-    return dispatchCompleted || selectionInvalid
-        ? nextState.clearSelection()
-        : nextState;
+        selectionInvalidAtStart ||
+        selectedIsland == null ||
+        selectedIsland.faction != Faction.player ||
+        selectedIsland.currentForces <= 1;
+    return selectionInvalid ? nextState.clearSelection() : nextState;
   }
 
   MovingForce createMovingForce({

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -48,6 +48,31 @@ final class IslandMapViewport {
       bottom: top + widgetSize,
     );
   }
+
+  /// Returns the screen-space distance travelled by a moving-force widget
+  /// between two normalized alignment positions.  [Align] positions the
+  /// center using `(viewport - child) * alignment / 2`, so each axis uses the
+  /// available travel span for the 30px troop widget rather than the raw
+  /// normalized coordinate span.
+  double movingForceDistance(
+    IslandPosition source,
+    IslandPosition destination,
+  ) {
+    final horizontalSpan = width - GameRules.movingForceWidgetSize;
+    final verticalSpan = height - GameRules.movingForceWidgetSize;
+    final deltaX = horizontalSpan * (destination.x - source.x) / 2;
+    final deltaY = verticalSpan * (destination.y - source.y) / 2;
+    return math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  }
+
+  /// The screen-space diagonal available to a moving-force widget.
+  double get movingForceScreenDiagonal {
+    final horizontalSpan = width - GameRules.movingForceWidgetSize;
+    final verticalSpan = height - GameRules.movingForceWidgetSize;
+    return math.sqrt(
+      horizontalSpan * horizontalSpan + verticalSpan * verticalSpan,
+    );
+  }
 }
 
 /// A renderer-independent rectangle for one island's square widget.
@@ -102,6 +127,7 @@ final class GameRules {
   /// in the API so a future renderer can give each variant its own size.
   static const headquartersWidgetSize = 100.0;
   static const neutralWidgetSize = 50.0;
+  static const movingForceWidgetSize = 30.0;
 
   /// A layout-independent fallback for state creation before Flutter layout
   /// constraints are available.  Callers with a real viewport should pass it
@@ -520,15 +546,16 @@ final class GameRules {
     required IslandState destination,
     required int strength,
     int departureTimeMs = 0,
+    IslandMapViewport viewport = defaultMapViewport,
   }) {
-    final distance = math.sqrt(
-      math.pow(destination.x - source.x, 2) +
-          math.pow(destination.y - source.y, 2),
+    final distance = viewport.movingForceDistance(
+      source.position,
+      destination.position,
     );
-    final durationMs = math.max(
-      1,
-      (movementDurationMs * distance / math.sqrt(8)).round(),
-    );
+    final screenDiagonal = viewport.movingForceScreenDiagonal;
+    final durationMs = screenDiagonal <= 0
+        ? 1
+        : math.max(1, (movementDurationMs * distance / screenDiagonal).round());
     return MovingForce(
       id: id,
       faction: faction,

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -114,13 +114,95 @@ void main() {
     controller.tapBase(1);
     final state = container.read(gameControllerProvider);
 
-    expect(state.selectedBaseId, 0);
+    expect(state.selectedBaseId, isNull);
     expect(state.movement, isNotNull);
     expect(state.movement!.sourceBaseId, 0);
     expect(state.movement!.targetBaseId, 1);
     expect(state.movement!.scale, 50);
     expect(state.bases[0].scale, 50);
   });
+
+  test(
+    'rejects non-player sources and deselects a source when tapped again',
+    () {
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
+
+      controller.tapBase(2);
+      expect(container.read(gameControllerProvider).selectedBaseId, isNull);
+
+      controller.tapBase(0);
+      expect(container.read(gameControllerProvider).selectedBaseId, 0);
+
+      controller.tapBase(0);
+      expect(container.read(gameControllerProvider).selectedBaseId, isNull);
+    },
+  );
+
+  test(
+    'uses force at destination tap time and clears an invalid selection',
+    () {
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
+      controller.tapBase(0);
+
+      final selected = container.read(gameControllerProvider);
+      final changedIslands = [
+        for (final island in selected.islands)
+          island.id == 0 ? island.copyWith(currentForces: 7) : island,
+      ];
+      controller.state = selected.copyWith(islands: changedIslands);
+      controller.tapBase(2);
+
+      final dispatched = container.read(gameControllerProvider);
+      expect(dispatched.movingForces.single.strength, 3);
+      expect(dispatched.islands.first.currentForces, 4);
+      expect(dispatched.selectedIslandId, isNull);
+
+      controller.tapBase(0);
+      final invalidated = container.read(gameControllerProvider);
+      controller.state = invalidated.copyWith(
+        islands: [
+          for (final island in invalidated.islands)
+            island.id == 0 ? island.copyWith(currentForces: 1) : island,
+        ],
+      );
+      loop.tick();
+
+      expect(container.read(gameControllerProvider).selectedIslandId, isNull);
+    },
+  );
+
+  test(
+    'dispatches floor half for zero, one, even, odd, and maximum forces',
+    () {
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
+      final playing = container.read(gameControllerProvider);
+
+      for (final force in [0, 1, 2, 5, 200]) {
+        controller.state = playing.copyWith(
+          islands: [
+            for (final island in playing.islands)
+              island.id == 0 ? island.copyWith(currentForces: force) : island,
+          ],
+        );
+        controller.tapBase(0);
+        controller.tapBase(2);
+
+        final state = container.read(gameControllerProvider);
+        final expectedDispatch = force ~/ 2;
+        if (expectedDispatch == 0) {
+          expect(state.movingForces, isEmpty, reason: 'force=$force');
+          expect(state.selectedIslandId, isNull, reason: 'force=$force');
+        } else {
+          expect(state.movingForces.single.strength, expectedDispatch);
+          expect(state.islands.first.currentForces, force - expectedDispatch);
+          expect(state.selectedIslandId, isNull, reason: 'force=$force');
+        }
+      }
+    },
+  );
 
   test('preserves a selected source across ticks before destination tap', () {
     final controller = container.read(gameControllerProvider.notifier);
@@ -135,7 +217,7 @@ void main() {
 
     controller.tapBase(1);
     final state = container.read(gameControllerProvider);
-    expect(state.selectedBaseId, 0);
+    expect(state.selectedBaseId, isNull);
     expect(state.movement, isNotNull);
   });
 
@@ -172,17 +254,62 @@ void main() {
     );
   });
 
-  test('preserves retargeting and re-halving while moving', () {
+  test('appends consecutive dispatches from one source', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
     controller.tapBase(0);
     controller.tapBase(1);
+    final first = container.read(gameControllerProvider).movingForces.single;
+
+    controller.tapBase(0);
     controller.tapBase(2);
 
     final state = container.read(gameControllerProvider);
-    expect(state.movement!.targetBaseId, 2);
-    expect(state.movement!.scale, 25);
+    expect(state.movingForces, hasLength(2));
+    expect(state.movingForces[0], first);
+    expect(state.movingForces[0].targetBaseId, 1);
+    expect(state.movingForces[0].scale, 50);
+    expect(state.movingForces[1].targetBaseId, 2);
+    expect(state.movingForces[1].scale, 25);
+    expect(state.movingForces[1].id, isNot(state.movingForces[0].id));
     expect(state.bases[0].scale, 25);
+    expect(state.selectedIslandId, isNull);
+  });
+
+  test('keeps troops from different sources independent', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+
+    final initial = container.read(gameControllerProvider);
+    controller.state = initial.copyWith(
+      islands: [
+        for (final island in initial.islands)
+          if (island.id == 2)
+            island.copyWith(faction: Faction.player, currentForces: 40)
+          else
+            island,
+      ],
+    );
+
+    controller.tapBase(0);
+    controller.tapBase(2);
+    controller.tapBase(2);
+    controller.tapBase(3);
+
+    final state = container.read(gameControllerProvider);
+    expect(state.movingForces, hasLength(2));
+    expect(
+      state.movingForces.map((force) => force.sourceIslandId),
+      orderedEquals([0, 2]),
+    );
+    expect(
+      state.movingForces.map((force) => force.destinationIslandId),
+      orderedEquals([2, 3]),
+    );
+    expect(
+      state.movingForces.map((force) => force.strength),
+      orderedEquals([50, 20]),
+    );
   });
 
   test('stops the loop when the provider is disposed', () {

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -571,6 +571,110 @@ void main() {
     },
   );
 
+  test('uses portrait screen distance for duration and arrival boundaries', () {
+    const viewport = IslandMapViewport(width: 390, height: 844);
+    const horizontalSource = IslandState(
+      id: 0,
+      position: IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      currentForces: 20,
+      capacity: 200,
+    );
+    const horizontalTarget = IslandState(
+      id: 1,
+      position: IslandPosition(x: 1, y: 0),
+      faction: Faction.neutral,
+      capacity: 50,
+    );
+    const verticalSource = IslandState(
+      id: 2,
+      position: IslandPosition(x: 0, y: -1),
+      faction: Faction.player,
+      currentForces: 20,
+      capacity: 200,
+    );
+    const verticalTarget = IslandState(
+      id: 3,
+      position: IslandPosition(x: 0, y: 0),
+      faction: Faction.neutral,
+      capacity: 50,
+    );
+    const diagonalSource = IslandState(
+      id: 4,
+      position: IslandPosition(x: -1, y: -1),
+      faction: Faction.player,
+      currentForces: 20,
+      capacity: 200,
+    );
+    const diagonalTarget = IslandState(
+      id: 5,
+      position: IslandPosition(x: 1, y: 1),
+      faction: Faction.neutral,
+      capacity: 50,
+    );
+
+    final horizontal = rules.createMovingForce(
+      id: 0,
+      faction: Faction.player,
+      source: horizontalSource,
+      destination: horizontalTarget,
+      strength: 5,
+      viewport: viewport,
+    );
+    final vertical = rules.createMovingForce(
+      id: 1,
+      faction: Faction.player,
+      source: verticalSource,
+      destination: verticalTarget,
+      strength: 5,
+      viewport: viewport,
+    );
+    final diagonal = rules.createMovingForce(
+      id: 2,
+      faction: Faction.player,
+      source: diagonalSource,
+      destination: diagonalTarget,
+      strength: 5,
+      viewport: viewport,
+    );
+
+    expect(
+      viewport.movingForceDistance(
+        horizontalSource.position,
+        horizontalTarget.position,
+      ),
+      closeTo(360, 1e-12),
+    );
+    expect(
+      viewport.movingForceDistance(
+        verticalSource.position,
+        verticalTarget.position,
+      ),
+      closeTo(407, 1e-12),
+    );
+    expect(
+      viewport.movingForceDistance(
+        diagonalSource.position,
+        diagonalTarget.position,
+      ),
+      closeTo(viewport.movingForceScreenDiagonal, 1e-12),
+    );
+    expect(vertical.durationMs, greaterThan(horizontal.durationMs));
+    expect(diagonal.durationMs, GameRules.movementDurationMs);
+
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: [verticalSource, verticalTarget],
+      movingForces: [vertical],
+    );
+    final beforeArrival = rules.tick(state, deltaMs: vertical.durationMs - 1);
+    expect(beforeArrival.movingForces, hasLength(1));
+
+    final atArrival = rules.tick(beforeArrival, deltaMs: 1);
+    expect(atArrival.movingForces, isEmpty);
+  });
+
   test(
     'keeps a troop until the tick before arrival and removes it at arrival',
     () {

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -521,6 +521,209 @@ void main() {
     expect(arrived.islands.last.currentForces, 32);
   });
 
+  test(
+    'movement duration is proportional to distance with a five-second diagonal',
+    () {
+      const source = IslandState(
+        id: 0,
+        position: IslandPosition(x: -1, y: -1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 40,
+        capacity: 200,
+      );
+      const diagonalTarget = IslandState(
+        id: 1,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.neutral,
+        size: IslandSize.small,
+        capacity: 50,
+      );
+      const nearTarget = IslandState(
+        id: 2,
+        position: IslandPosition(x: 0, y: -1),
+        faction: Faction.neutral,
+        size: IslandSize.small,
+        capacity: 50,
+      );
+
+      final diagonal = rules.createMovingForce(
+        id: 10,
+        faction: Faction.player,
+        source: source,
+        destination: diagonalTarget,
+        strength: 20,
+        departureTimeMs: 1200,
+      );
+      final near = rules.createMovingForce(
+        id: 11,
+        faction: Faction.player,
+        source: source,
+        destination: nearTarget,
+        strength: 20,
+        departureTimeMs: 1200,
+      );
+
+      expect(diagonal.durationMs, 5000);
+      expect(diagonal.arrivalTimeMs, 6200);
+      expect(near.durationMs, lessThan(diagonal.durationMs));
+      expect(near.arrivalTimeMs, 1200 + near.durationMs);
+    },
+  );
+
+  test(
+    'keeps a troop until the tick before arrival and removes it at arrival',
+    () {
+      const source = IslandState(
+        id: 0,
+        position: IslandPosition(x: -1, y: -1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 40,
+        capacity: 200,
+      );
+      const target = IslandState(
+        id: 1,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 10,
+        capacity: 200,
+      );
+      final force = rules.createMovingForce(
+        id: 0,
+        faction: Faction.player,
+        source: source,
+        destination: target,
+        strength: 15,
+      );
+      final state = GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: [source, target],
+        movingForces: [force],
+      );
+
+      final beforeArrival = rules.tick(state, deltaMs: force.durationMs - 1);
+      expect(beforeArrival.movingForces, hasLength(1));
+      expect(beforeArrival.movingForces.single.progress, lessThan(1));
+      expect(
+        beforeArrival.movingForces.single.arrivalTimeMs,
+        force.arrivalTimeMs,
+      );
+
+      final atArrival = rules.tick(beforeArrival, deltaMs: 1);
+      expect(atArrival.movingForces, isEmpty);
+      expect(atArrival.islands.last.currentForces, 30);
+    },
+  );
+
+  test(
+    'updates multiple troops independently without in-flight collisions',
+    () {
+      const firstSource = IslandState(
+        id: 0,
+        position: IslandPosition(x: -1, y: 0),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 40,
+        capacity: 200,
+      );
+      const firstTarget = IslandState(
+        id: 1,
+        position: IslandPosition(x: 0, y: 0),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 10,
+        capacity: 200,
+      );
+      const secondSource = IslandState(
+        id: 2,
+        position: IslandPosition(x: 0, y: -1),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 40,
+        capacity: 200,
+      );
+      const secondTarget = IslandState(
+        id: 3,
+        position: IslandPosition(x: 0, y: 1),
+        faction: Faction.neutral,
+        size: IslandSize.small,
+        capacity: 50,
+      );
+      final first = rules.createMovingForce(
+        id: 0,
+        faction: Faction.player,
+        source: firstSource,
+        destination: firstTarget,
+        strength: 15,
+      );
+      final second = rules.createMovingForce(
+        id: 1,
+        faction: Faction.player,
+        source: secondSource,
+        destination: secondTarget,
+        strength: 7,
+      );
+      final state = GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        selectedIslandId: 2,
+        islands: [firstSource, firstTarget, secondSource, secondTarget],
+        movingForces: [first, second],
+      );
+
+      final next = rules.tick(state, deltaMs: first.durationMs);
+      expect(next.movingForces, hasLength(1));
+      expect(next.movingForces.single.id, second.id);
+      expect(next.islands[1].currentForces, 26);
+      expect(next.islands[3].currentForces, 1);
+      expect(next.movingForces.single.progress, lessThan(1));
+      expect(
+        next.movingForces.single.position,
+        const IslandPosition(x: 0, y: 0),
+      );
+      expect(next.selectedIslandId, 2);
+    },
+  );
+
+  test(
+    'invalidates a selected source when ownership or force becomes invalid',
+    () {
+      const source = IslandState(
+        id: 0,
+        position: IslandPosition(x: 0, y: 0),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 10,
+        capacity: 200,
+      );
+      const target = IslandState(
+        id: 1,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.neutral,
+        size: IslandSize.small,
+        capacity: 50,
+      );
+      final ownershipChanged = GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 100,
+        selectedIslandId: 0,
+        islands: [
+          source.copyWith(faction: Faction.cpu),
+          target,
+        ],
+      );
+      final forceExhausted = ownershipChanged.copyWith(
+        islands: [source.copyWith(currentForces: 1), target],
+      );
+
+      expect(rules.tick(ownershipChanged, deltaMs: 0).selectedIslandId, isNull);
+      expect(rules.tick(forceExhausted, deltaMs: 0).selectedIslandId, isNull);
+    },
+  );
+
   test('controller uses an injected clock with a manual loop', () {
     final clock = FixedClock();
     final loop = ManualGameLoop();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -202,7 +202,7 @@ void main() {
       expect(before.islands, hasLength(6));
       expect(before.elapsedMs, greaterThan(0));
       expect(before.movingForces, isNotEmpty);
-      expect(before.selectedIslandId, 0);
+      expect(before.selectedIslandId, isNull);
 
       await tester.binding.setSurfaceSize(const Size(321, 500));
       await tester.pump();
@@ -215,7 +215,7 @@ void main() {
       expect(after.islands, hasLength(6));
       expect(after.elapsedMs, before.elapsedMs);
       expect(after.movingForces, before.movingForces);
-      expect(after.selectedIslandId, before.selectedIslandId);
+      expect(after.selectedIslandId, isNull);
       expect(loop.isRunning, isTrue);
 
       loop.tick();
@@ -265,7 +265,7 @@ void main() {
     expect(after.phase, GamePhase.playing);
     expect(after.elapsedMs, before.elapsedMs);
     expect(after.islands, before.islands);
-    expect(after.selectedIslandId, before.selectedIslandId);
+    expect(after.selectedIslandId, isNull);
     expect(after.movingForces, before.movingForces);
     expect(loop.isRunning, isTrue);
 


### PR DESCRIPTION
## 概要

自軍島の選択から出兵までの操作ルールをゲームエンジンへ実装し、同一・複数の出兵元から複数部隊を同時に保持できるようにしました。部隊の到着時間は実viewport上の移動距離に比例し、画面対角線を約5秒とする決定論的な時刻情報を保持します。

## 背景・目的

従来は単一の移動状態しか保持できず、移動時間も画面上の距離に比例していませんでした。Issue #8 の仕様どおり、最新兵力の半分を出兵し、複数部隊を独立して更新できるエンジン境界を整えます。

## 対応内容

- 自軍島の選択・再選択解除・所有権/兵力による自動無効化を実装
- 移動先タップ時の最新兵力から `floor(兵力 / 2)` を出兵し、成功時に選択を解除
- 決定論的IDと出発/到着時刻を持つ複数部隊を追加保持
- 実viewportの画素距離と画面対角線を基準に、一定速度・距離比例の移動時間を算出
- 到着直前/到着時、連続出兵、複数出兵元、移動中の非干渉をテスト

## 主な設計判断

- 到着後の増援・戦闘は既存境界のままにし、Issue #8 では移動状態とタイミングだけを変更
- Issue #7 で導入済みの `IslandMapViewport` と描画ジオメトリを再利用し、`Align` の正規化距離ではなく実画面上の距離を採用
- 部隊IDは同時に存在する部隊間で決定論的に一意となるよう、現在のactive IDから次値を決定

## 受け入れ条件との対応

- [x] 兵力5から2を出兵し、3を残す
- [x] 兵力1以下では部隊を作成しない
- [x] 移動先タップ時の最新兵力を使用する
- [x] 同じ出兵元から到着前に複数部隊を作成する
- [x] 異なる出兵元の部隊を同時に保持・更新する
- [x] 実画面上で近い島ほど早く、遠い島ほど遅く到着する
- [x] 実画面対角線の移動時間を約5秒とする
- [x] 移動経路上の島・部隊で進路や兵力を変えない
- [x] 選択解除と無効化条件を仕様どおりに扱う
- [x] Flutter analyzeと全テストが成功する

## 検証

- `fvm dart format lib/game/game_controller.dart lib/game/game_rules.dart test/game_controller_test.dart test/game_rules_test.dart test/widget_test.dart`: 成功
- `git diff --check origin/main...HEAD`: 成功
- `fvm flutter analyze`: 成功（No issues found!）
- `fvm flutter test`: 成功（All tests passed!）

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `c83aa5d788feb3f19bd722359bdc22e6909ba3d5`）
- GitHub Codex review（1回のみ）: 指摘なし（review HEAD: `c83aa5d788feb3f19bd722359bdc22e6909ba3d5`）
- Required checks: 対象なし

## 残存リスク

GitHub required checksは設定されていないため、CIによる強制はありません。current HEADはローカル検証と2回目の`final_reviewer`承認、1回限りのGitHub Codex reviewで確認済みです。到着後の増援・戦闘、部隊Widget・アニメーション、CPU出兵はIssue #8の対象外です。

Closes #8
