### PR TITLE
feat: 毎秒の兵力増加・上限・イベント順序を実装

### DIFF
--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -446,16 +446,21 @@ final class GameRules {
             selectedAtStart.faction != Faction.player ||
             selectedAtStart.currentForces <= 1);
 
-    // Resource ticks are represented here as a deterministic time boundary;
-    // concrete ownership/combat rules can later replace this helper without
-    // changing controller or loop orchestration.
+    // Each crossed boundary is one shared game-time growth event.  Neutral
+    // islands retain their durability and do not receive troop growth.
     final resourceTicks = elapsedMs ~/ 1000 - state.elapsedMs ~/ 1000;
-    for (var tick = 0; tick < resourceTicks; tick++) {
+    if (resourceTicks > 0) {
       islands = [
         for (final island in islands)
-          island.copyWith(
-            currentForces: math.min(island.capacity, island.currentForces + 1),
-          ),
+          if (island.faction == Faction.neutral)
+            island
+          else
+            island.copyWith(
+              currentForces: math.min(
+                island.capacity,
+                island.currentForces + resourceTicks,
+              ),
+            ),
       ];
     }
 

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -238,21 +238,24 @@ void main() {
     expect(state.bases[1].scale, 155);
   });
 
-  test('increments every base after one second', () {
-    final controller = container.read(gameControllerProvider.notifier);
-    controller.startGame();
+  test(
+    'increments owned bases after one second without growing neutral bases',
+    () {
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
 
-    for (var i = 0; i < 20; i++) {
-      loop.tick();
-    }
+      for (var i = 0; i < 20; i++) {
+        loop.tick();
+      }
 
-    final state = container.read(gameControllerProvider);
-    expect(state.elapsedMs, 1000);
-    expect(
-      state.bases.every((base) => base.scale == (base.id < 2 ? 101 : 1)),
-      isTrue,
-    );
-  });
+      final state = container.read(gameControllerProvider);
+      expect(state.elapsedMs, 1000);
+      expect(
+        state.bases.every((base) => base.scale == (base.id < 2 ? 101 : 0)),
+        isTrue,
+      );
+    },
+  );
 
   test('appends consecutive dispatches from one source', () {
     final controller = container.read(gameControllerProvider.notifier);

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -481,6 +481,232 @@ void main() {
     },
   );
 
+  test(
+    'grows player and CPU islands but never neutral durability or forces',
+    () {
+      const playerIsland = IslandState(
+        id: 0,
+        faction: Faction.player,
+        size: IslandSize.small,
+        currentForces: 10,
+      );
+      const cpuIsland = IslandState(
+        id: 1,
+        faction: Faction.cpu,
+        size: IslandSize.medium,
+        currentForces: 20,
+      );
+      const neutralIsland = IslandState(
+        id: 2,
+        faction: Faction.neutral,
+        size: IslandSize.large,
+        currentForces: 7,
+        durability: 30,
+      );
+      final state = GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: const [playerIsland, cpuIsland, neutralIsland],
+      );
+
+      final next = rules.tick(state, deltaMs: 1000);
+
+      expect(next.islands[0].currentForces, 11);
+      expect(next.islands[1].currentForces, 21);
+      expect(next.islands[2].currentForces, 7);
+      expect(next.islands[2].durability, 30);
+    },
+  );
+
+  test('stops growth at the size and headquarters capacity', () {
+    const islands = [
+      IslandState(
+        id: 0,
+        faction: Faction.player,
+        size: IslandSize.small,
+        currentForces: 49,
+      ),
+      IslandState(
+        id: 1,
+        faction: Faction.cpu,
+        size: IslandSize.medium,
+        currentForces: 99,
+      ),
+      IslandState(
+        id: 2,
+        faction: Faction.player,
+        size: IslandSize.large,
+        currentForces: 149,
+      ),
+      IslandState(
+        id: 3,
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 199,
+      ),
+      IslandState(
+        id: 4,
+        faction: Faction.player,
+        size: IslandSize.small,
+        currentForces: 50,
+      ),
+      IslandState(
+        id: 5,
+        faction: Faction.cpu,
+        size: IslandSize.medium,
+        currentForces: 100,
+      ),
+      IslandState(
+        id: 6,
+        faction: Faction.player,
+        size: IslandSize.large,
+        currentForces: 150,
+      ),
+      IslandState(
+        id: 7,
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 200,
+      ),
+    ];
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: islands,
+    );
+
+    final next = rules.tick(state, deltaMs: 1000);
+
+    expect(
+      next.islands.map((island) => island.currentForces),
+      orderedEquals([50, 100, 150, 200, 50, 100, 150, 200]),
+    );
+    expect(
+      next.islands.map((island) => island.capacity),
+      orderedEquals([50, 100, 150, 200, 50, 100, 150, 200]),
+    );
+  });
+
+  test('counts one-second boundaries at 999, 1000, and 1001 milliseconds', () {
+    const island = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 0,
+    );
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: const [island],
+    );
+
+    final beforeBoundary = rules.tick(state, deltaMs: 999);
+    expect(beforeBoundary.elapsedMs, 999);
+    expect(beforeBoundary.islands.single.currentForces, 0);
+
+    final atBoundary = rules.tick(beforeBoundary, deltaMs: 1);
+    expect(atBoundary.elapsedMs, 1000);
+    expect(atBoundary.islands.single.currentForces, 1);
+
+    final afterBoundary = rules.tick(atBoundary, deltaMs: 1);
+    expect(afterBoundary.elapsedMs, 1001);
+    expect(afterBoundary.islands.single.currentForces, 1);
+  });
+
+  test('preserves every crossed growth boundary in a long tick', () {
+    const island = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 0,
+    );
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: const [island],
+    );
+
+    final next = rules.tick(state, deltaMs: 3500);
+
+    expect(next.elapsedMs, 3500);
+    expect(next.islands.single.currentForces, 3);
+  });
+
+  test('applies growth before an arrival at the same timestamp', () {
+    const source = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 20,
+      position: IslandPosition(x: -1, y: 0),
+    );
+    const target = IslandState(
+      id: 1,
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 10,
+      position: IslandPosition(x: 1, y: 0),
+    );
+    const force = MovingForce(
+      id: 0,
+      faction: Faction.player,
+      sourceIslandId: 0,
+      destinationIslandId: 1,
+      strength: 5,
+      departureTimeMs: 0,
+      arrivalTimeMs: 1000,
+      durationMs: 1000,
+    );
+    final state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: const [source, target],
+      movingForces: const [force],
+    );
+
+    final next = rules.tick(state, deltaMs: 1000);
+
+    expect(next.movingForces, isEmpty);
+    expect(next.islands[1].currentForces, 16);
+  });
+
+  test('does not advance game time or troops outside the playing phase', () {
+    const island = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 10,
+    );
+    final configuration = GameState(
+      phase: GamePhase.configuration,
+      elapsedMs: 0,
+      islands: const [island],
+    );
+    final countdown = rules.startCountdown(configuration, durationMs: 1000);
+    final paused = configuration.copyWith(phase: GamePhase.paused);
+    final resumeCountdown = rules.resumeCountdown(paused, durationMs: 1000);
+    final result = configuration.copyWith(
+      phase: GamePhase.result,
+      result: const GameResult.draw(elapsedMs: 0),
+    );
+
+    for (final state in [
+      configuration,
+      countdown,
+      paused,
+      resumeCountdown,
+      result,
+    ]) {
+      final next = rules.tick(state, deltaMs: 2000);
+      expect(next.elapsedMs, state.elapsedMs, reason: state.phase.name);
+      expect(
+        next.islands.map((island) => island.currentForces),
+        orderedEquals(state.islands.map((island) => island.currentForces)),
+        reason: state.phase.name,
+      );
+    }
+  });
+
   test('a moving force advances by time and arrives deterministically', () {
     const source = IslandState(
       id: 0,
@@ -782,7 +1008,7 @@ void main() {
       expect(next.movingForces, hasLength(1));
       expect(next.movingForces.single.id, second.id);
       expect(next.islands[1].currentForces, 26);
-      expect(next.islands[3].currentForces, 1);
+      expect(next.islands[3].currentForces, 0);
       expect(next.movingForces.single.progress, lessThan(1));
       expect(
         next.movingForces.single.position,


### PR DESCRIPTION
## 概要

ゲーム内の共通経過時間に基づき、プレイヤー軍とCPU軍の所有島へ1秒ごとに兵力を加算します。任意tick幅と長いtickでも境界を取りこぼさず、島ごとの上限、中立島の非増加、同時刻の兵力増加優先を決定論的に扱います。

## 背景・目的

Issue #9で定義された、プレイ中だけ進む共通ゲーム時間、毎秒の兵力増加、上限適用、到着イベントとの順序をGameRulesへ実装し、将来の戦闘処理でも同じ時刻順序を維持できる基盤を整えます。

## 対応内容

- GameRules.tickで跨いだ1秒境界数を算術的に算出
- プレイヤー軍・CPU軍の所有島だけを同じ境界で増加
- 小50・中100・大150・本陣200のcapacityで上限を適用
- 中立島、カウントダウン、一時停止、結果フェーズの非増加を維持
- 兵力増加後に同時刻の到着処理を行う順序を回帰テストで固定

## 主な設計判断

- 固定50ms tickの繰り返しではなく、更新前後の共通経過時間から跨いだ秒境界数を求め、任意幅・複数秒跨ぎで取りこぼしを防止
- 既存IslandState.capacityを上限の唯一の根拠として利用し、島種別の上限定義を重複させない
- 到着後の戦闘・占領はIssue #10の範囲に残し、本PRでは既存の到着処理seamに対する増加優先順序を保証

## 受け入れ条件との対応

- [x] 所有島はゲーム内時間1秒ごとに兵力が1増える
- [x] 両軍の島を同じタイミングで更新する
- [x] 中立島の耐久力は時間経過で変化しない
- [x] 小50・中100・大150・本陣200の上限を超えない
- [x] 999ms・1000ms・1001msを含む50ms以外のtick幅で境界を処理する
- [x] 長いtickで複数秒境界を跨いでも増加回数を失わない
- [x] 増加と到着が同時刻なら増加後の値を到着処理へ渡す
- [x] 非プレイフェーズでは時間と兵力を変更しない
- [x] Flutter analyzeと全テストが成功する

## 検証

- fvm dart format --output=none --set-exit-if-changed lib/game/game_rules.dart test/game_controller_test.dart test/game_rules_test.dart: 成功
- git diff --check: 成功
- fvm flutter test test/game_rules_test.dart test/game_controller_test.dart: 成功（43 tests）
- fvm flutter analyze: 成功（No issues found）
- fvm flutter test: 成功（51 tests）

## レビュー結果

- Local final_reviewer: 承認（HEAD: 41ad84770231b8eec871905ac5e97d4e0aa9ddfd）
- GitHub Codex review（1回のみ）: 指摘なし（review HEAD: 41ad84770231b8eec871905ac5e97d4e0aa9ddfd）
- Required checks: 対象なし

## 残存リスク

到着後の増援・戦闘・占領解決はIssue #10の対象であり、本PRでは既存の到着処理seamまでを検証しています。

Closes #9