### PR TITLE
feat: 増援・戦闘・勝敗判定を実装

### DIFF
--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -276,7 +276,12 @@ class GameController extends _$GameController {
         ? 0
         : now - previous;
     final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
-    state = _rules.tick(state, deltaMs: deltaMs);
+    final nextState = _rules.tick(state, deltaMs: deltaMs);
+    state = nextState;
+    if (nextState.phase == GamePhase.result) {
+      _gameLoop.stop();
+      _lastTickMs = null;
+    }
   }
 
   IslandState? _findIsland(int id) {

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -405,7 +405,13 @@ final class GameRules {
     return state.finishWithResult(result);
   }
 
-  /// Advances countdowns and the time-based foundation state.
+  /// Advances countdowns, growth, movement, and arrival events.
+  ///
+  /// Arrivals are handled as chronological event groups.  Growth boundaries
+  /// are applied immediately before an arrival at the same timestamp, while
+  /// all arrivals in one timestamp are removed and resolved together.  This
+  /// keeps the result independent of the order in which moving forces happen
+  /// to be stored in the state list.
   GameState tick(GameState state, {required int deltaMs}) {
     if (deltaMs < 0) {
       throw ArgumentError.value(deltaMs, 'deltaMs', 'must not be negative');
@@ -424,8 +430,11 @@ final class GameRules {
       return state;
     }
 
-    final elapsedMs = state.elapsedMs + deltaMs;
+    final startMs = state.elapsedMs;
+    final endMs = startMs + deltaMs;
+    var currentMs = startMs;
     var islands = [...state.islands];
+    final remainingForces = [...state.movingForces];
 
     // Validate an existing selection before applying resource ticks.  A
     // source that was already exhausted or lost before this tick must not be
@@ -446,50 +455,198 @@ final class GameRules {
             selectedAtStart.faction != Faction.player ||
             selectedAtStart.currentForces <= 1);
 
-    // Each crossed boundary is one shared game-time growth event.  Neutral
-    // islands retain their durability and do not receive troop growth.
-    final resourceTicks = elapsedMs ~/ 1000 - state.elapsedMs ~/ 1000;
-    if (resourceTicks > 0) {
-      islands = [
-        for (final island in islands)
-          if (island.faction == Faction.neutral)
-            island
-          else
-            island.copyWith(
-              currentForces: math.min(
-                island.capacity,
-                island.currentForces + resourceTicks,
-              ),
-            ),
-      ];
+    final arrivalsByTime = <int, List<MovingForce>>{};
+    for (final force in remainingForces) {
+      final eventTime = math.max(force.arrivalTimeMs, force.departureTimeMs);
+      if (eventTime <= endMs) {
+        arrivalsByTime.putIfAbsent(eventTime, () => []).add(force);
+      }
     }
 
-    final remainingForces = <MovingForce>[];
-    for (final force in state.movingForces) {
+    final arrivalTimes = arrivalsByTime.keys.toList()..sort();
+    for (final arrivalTime in arrivalTimes) {
+      final eventTime = math.max(startMs, arrivalTime);
+      islands = _applyGrowth(islands, fromMs: currentMs, toMs: eventTime);
+      currentMs = eventTime;
+
+      final group = arrivalsByTime[arrivalTime]!;
+      final groupIds = group.map((force) => force.id).toSet();
+      remainingForces.removeWhere((force) => groupIds.contains(force.id));
+      islands = _resolveArrivalGroup(islands, group);
+
+      final eventState = _stateAtTime(
+        state,
+        elapsedMs: currentMs,
+        islands: islands,
+        movingForces: _updateMovingForcePositions(
+          remainingForces,
+          islands,
+          currentMs,
+        ),
+        selectionInvalidAtStart: selectionInvalidAtStart,
+      );
+      final result = _resultFor(
+        elapsedMs: currentMs,
+        islands: eventState.islands,
+        movingForces: eventState.movingForces,
+      );
+      if (result != null) {
+        return eventState.finishWithResult(result);
+      }
+    }
+
+    islands = _applyGrowth(islands, fromMs: currentMs, toMs: endMs);
+    final nextState = _stateAtTime(
+      state,
+      elapsedMs: endMs,
+      islands: islands,
+      movingForces: _updateMovingForcePositions(
+        remainingForces,
+        islands,
+        endMs,
+      ),
+      selectionInvalidAtStart: selectionInvalidAtStart,
+    );
+
+    final result = _resultFor(
+      elapsedMs: endMs,
+      islands: nextState.islands,
+      movingForces: nextState.movingForces,
+    );
+    if (result != null) {
+      return nextState.finishWithResult(result);
+    }
+
+    return nextState;
+  }
+
+  /// Resolves one arriving faction against an island.
+  ///
+  /// A neutral island uses [IslandState.durability] as its defense value;
+  /// owned islands use [IslandState.currentForces].  Strictly greater attack
+  /// strength captures the island, while equal strength leaves the owner in
+  /// place with a zero value.
+  IslandState resolveArrival(
+    IslandState island,
+    Faction faction,
+    int strength,
+  ) {
+    if (strength <= 0 || faction == Faction.neutral) {
+      return island;
+    }
+
+    if (island.faction == faction) {
+      return island.copyWith(
+        currentForces: math.min(
+          island.capacity,
+          island.currentForces + strength,
+        ),
+      );
+    }
+
+    if (island.faction == Faction.neutral) {
+      final defense = math.max(0, island.durability);
+      if (strength > defense) {
+        return island.copyWith(
+          faction: faction,
+          currentForces: math.min(island.capacity, strength - defense),
+          durability: 0,
+        );
+      }
+      return island.copyWith(currentForces: 0, durability: defense - strength);
+    }
+
+    final defense = math.max(0, island.currentForces);
+    if (strength > defense) {
+      return island.copyWith(
+        faction: faction,
+        currentForces: math.min(island.capacity, strength - defense),
+        durability: 0,
+      );
+    }
+    return island.copyWith(currentForces: defense - strength);
+  }
+
+  List<IslandState> _resolveArrivalGroup(
+    List<IslandState> islands,
+    List<MovingForce> group,
+  ) {
+    final arrivalsByTarget = <int, Map<Faction, int>>{};
+    for (final force in group) {
+      if (force.strength <= 0 || force.faction == Faction.neutral) {
+        continue;
+      }
+      final byFaction = arrivalsByTarget.putIfAbsent(
+        force.destinationIslandId,
+        () => <Faction, int>{},
+      );
+      byFaction[force.faction] =
+          (byFaction[force.faction] ?? 0) + force.strength;
+    }
+
+    final nextIslands = [...islands];
+    for (final entry in arrivalsByTarget.entries) {
+      final targetIndex = nextIslands.indexWhere(
+        (island) => island.id == entry.key,
+      );
+      if (targetIndex < 0) {
+        continue;
+      }
+      final playerStrength = entry.value[Faction.player] ?? 0;
+      final cpuStrength = entry.value[Faction.cpu] ?? 0;
+      if (playerStrength == cpuStrength) {
+        continue;
+      }
+      final faction = playerStrength > cpuStrength
+          ? Faction.player
+          : Faction.cpu;
+      final strength = playerStrength > cpuStrength
+          ? playerStrength - cpuStrength
+          : cpuStrength - playerStrength;
+      nextIslands[targetIndex] = resolveArrival(
+        nextIslands[targetIndex],
+        faction,
+        strength,
+      );
+    }
+    return nextIslands;
+  }
+
+  List<IslandState> _applyGrowth(
+    List<IslandState> islands, {
+    required int fromMs,
+    required int toMs,
+  }) {
+    final resourceTicks = toMs ~/ 1000 - fromMs ~/ 1000;
+    if (resourceTicks <= 0) {
+      return islands;
+    }
+    return [
+      for (final island in islands)
+        if (island.faction == Faction.neutral)
+          island
+        else
+          island.copyWith(
+            currentForces: math.min(
+              island.capacity,
+              island.currentForces + resourceTicks,
+            ),
+          ),
+    ];
+  }
+
+  List<MovingForce> _updateMovingForcePositions(
+    List<MovingForce> movingForces,
+    List<IslandState> islands,
+    int elapsedMs,
+  ) {
+    final nextForces = <MovingForce>[];
+    for (final force in movingForces) {
       final duration = math.max(1, force.durationMs);
       final elapsedSinceDeparture = elapsedMs - force.departureTimeMs;
       final nextProgress = elapsedSinceDeparture <= 0
           ? 0.0
           : math.min(1.0, elapsedSinceDeparture / duration);
-      final atArrivalBoundary =
-          elapsedMs >= force.arrivalTimeMs &&
-          elapsedMs >= force.departureTimeMs;
-      if (nextProgress >= 1.0 || atArrivalBoundary) {
-        final targetIndex = islands.indexWhere(
-          (island) => island.id == force.destinationIslandId,
-        );
-        if (targetIndex >= 0) {
-          final target = islands[targetIndex];
-          islands[targetIndex] = target.copyWith(
-            currentForces: math.min(
-              target.capacity,
-              target.currentForces + force.strength,
-            ),
-          );
-        }
-        continue;
-      }
-
       final source = islands.firstWhere(
         (island) => island.id == force.sourceIslandId,
         orElse: () => const IslandState(
@@ -506,7 +663,7 @@ final class GameRules {
         x: source.x + (target.x - source.x) * nextProgress,
         y: source.y + (target.y - source.y) * nextProgress,
       );
-      remainingForces.add(
+      nextForces.add(
         force.copyWith(
           position: nextPosition,
           progress: nextProgress,
@@ -515,11 +672,20 @@ final class GameRules {
         ),
       );
     }
+    return nextForces;
+  }
 
+  GameState _stateAtTime(
+    GameState state, {
+    required int elapsedMs,
+    required List<IslandState> islands,
+    required List<MovingForce> movingForces,
+    required bool selectionInvalidAtStart,
+  }) {
     final nextState = state.copyWith(
       elapsedMs: elapsedMs,
       islands: islands,
-      movingForces: remainingForces,
+      movingForces: movingForces,
     );
 
     // A selected source remains active while the player is choosing a
@@ -542,6 +708,34 @@ final class GameRules {
         selectedIsland.faction != Faction.player ||
         selectedIsland.currentForces <= 1;
     return selectionInvalid ? nextState.clearSelection() : nextState;
+  }
+
+  GameResult? _resultFor({
+    required int elapsedMs,
+    required List<IslandState> islands,
+    required List<MovingForce> movingForces,
+  }) {
+    final playerAlive =
+        islands.any((island) => island.faction == Faction.player) ||
+        movingForces.any(
+          (force) => force.faction == Faction.player && force.strength > 0,
+        );
+    final cpuAlive =
+        islands.any((island) => island.faction == Faction.cpu) ||
+        movingForces.any(
+          (force) => force.faction == Faction.cpu && force.strength > 0,
+        );
+
+    if (playerAlive && cpuAlive) {
+      return null;
+    }
+    if (!playerAlive && !cpuAlive) {
+      return GameResult.draw(elapsedMs: elapsedMs);
+    }
+    if (!playerAlive) {
+      return GameResult.defeat(elapsedMs: elapsedMs, winner: Faction.cpu);
+    }
+    return GameResult.victory(elapsedMs: elapsedMs, winner: Faction.player);
   }
 
   MovingForce createMovingForce({

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -464,6 +464,7 @@ final class GameRules {
     }
 
     final arrivalTimes = arrivalsByTime.keys.toList()..sort();
+    var stateAtCurrentTime = state;
     for (final arrivalTime in arrivalTimes) {
       final eventTime = math.max(startMs, arrivalTime);
       islands = _applyGrowth(islands, fromMs: currentMs, toMs: eventTime);
@@ -475,7 +476,7 @@ final class GameRules {
       islands = _resolveArrivalGroup(islands, group);
 
       final eventState = _stateAtTime(
-        state,
+        stateAtCurrentTime,
         elapsedMs: currentMs,
         islands: islands,
         movingForces: _updateMovingForcePositions(
@@ -485,6 +486,7 @@ final class GameRules {
         ),
         selectionInvalidAtStart: selectionInvalidAtStart,
       );
+      stateAtCurrentTime = eventState;
       final result = _resultFor(
         elapsedMs: currentMs,
         islands: eventState.islands,
@@ -497,7 +499,7 @@ final class GameRules {
 
     islands = _applyGrowth(islands, fromMs: currentMs, toMs: endMs);
     final nextState = _stateAtTime(
-      state,
+      stateAtCurrentTime,
       elapsedMs: endMs,
       islands: islands,
       movingForces: _updateMovingForcePositions(

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -235,7 +235,51 @@ void main() {
     expect(state.movement, isNull);
     expect(state.selectedBaseId, isNull);
     expect(state.bases[0].scale, 55);
-    expect(state.bases[1].scale, 155);
+    expect(state.bases[1].scale, 55);
+  });
+
+  test('stops the game loop when arrival resolution finalizes a result', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    controller.state = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: const [
+        IslandState(
+          id: 0,
+          faction: Faction.player,
+          size: IslandSize.small,
+          currentForces: 1,
+          capacity: 50,
+        ),
+        IslandState(
+          id: 1,
+          faction: Faction.cpu,
+          size: IslandSize.small,
+          currentForces: 100,
+          capacity: 50,
+        ),
+      ],
+      movingForces: const [
+        MovingForce(
+          id: 0,
+          faction: Faction.cpu,
+          sourceIslandId: 1,
+          destinationIslandId: 0,
+          strength: 2,
+          arrivalTimeMs: 0,
+          durationMs: 1,
+        ),
+      ],
+    );
+
+    loop.tick();
+
+    final result = container.read(gameControllerProvider);
+    expect(result.phase, GamePhase.result);
+    expect(result.result?.type, GameResultType.defeat);
+    expect(loop.isRunning, isFalse);
+    expect(loop.stopCount, 1);
   });
 
   test(

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -594,23 +594,29 @@ void main() {
       size: IslandSize.small,
       currentForces: 0,
     );
+    const cpu = IslandState(
+      id: 1,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 0,
+    );
     final state = GameState(
       phase: GamePhase.playing,
       elapsedMs: 0,
-      islands: const [island],
+      islands: const [island, cpu],
     );
 
     final beforeBoundary = rules.tick(state, deltaMs: 999);
     expect(beforeBoundary.elapsedMs, 999);
-    expect(beforeBoundary.islands.single.currentForces, 0);
+    expect(beforeBoundary.islands.first.currentForces, 0);
 
     final atBoundary = rules.tick(beforeBoundary, deltaMs: 1);
     expect(atBoundary.elapsedMs, 1000);
-    expect(atBoundary.islands.single.currentForces, 1);
+    expect(atBoundary.islands.first.currentForces, 1);
 
     final afterBoundary = rules.tick(atBoundary, deltaMs: 1);
     expect(afterBoundary.elapsedMs, 1001);
-    expect(afterBoundary.islands.single.currentForces, 1);
+    expect(afterBoundary.islands.first.currentForces, 1);
   });
 
   test('preserves every crossed growth boundary in a long tick', () {
@@ -620,16 +626,22 @@ void main() {
       size: IslandSize.headquarters,
       currentForces: 0,
     );
+    const cpu = IslandState(
+      id: 1,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 0,
+    );
     final state = GameState(
       phase: GamePhase.playing,
       elapsedMs: 0,
-      islands: const [island],
+      islands: const [island, cpu],
     );
 
     final next = rules.tick(state, deltaMs: 3500);
 
     expect(next.elapsedMs, 3500);
-    expect(next.islands.single.currentForces, 3);
+    expect(next.islands.first.currentForces, 3);
   });
 
   test('applies growth before an arrival at the same timestamp', () {
@@ -724,6 +736,13 @@ void main() {
       currentForces: 10,
       capacity: 200,
     );
+    const cpu = IslandState(
+      id: 2,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 0,
+      capacity: 200,
+    );
     final force = rules.createMovingForce(
       id: 0,
       faction: Faction.player,
@@ -734,7 +753,7 @@ void main() {
     final state = GameState(
       phase: GamePhase.playing,
       elapsedMs: 0,
-      islands: [source, target],
+      islands: [source, target, cpu],
       movingForces: [force],
     );
 
@@ -744,7 +763,7 @@ void main() {
 
     final arrived = rules.tick(halfway, deltaMs: force.durationMs);
     expect(arrived.movingForces, isEmpty);
-    expect(arrived.islands.last.currentForces, 32);
+    expect(arrived.islands[1].currentForces, 32);
   });
 
   test(
@@ -825,6 +844,13 @@ void main() {
       faction: Faction.neutral,
       capacity: 50,
     );
+    const cpu = IslandState(
+      id: 99,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 0,
+      capacity: 200,
+    );
     const diagonalSource = IslandState(
       id: 4,
       position: IslandPosition(x: -1, y: -1),
@@ -891,7 +917,7 @@ void main() {
     final state = GameState(
       phase: GamePhase.playing,
       elapsedMs: 0,
-      islands: [verticalSource, verticalTarget],
+      islands: [verticalSource, verticalTarget, cpu],
       movingForces: [vertical],
     );
     final beforeArrival = rules.tick(state, deltaMs: vertical.durationMs - 1);
@@ -920,6 +946,13 @@ void main() {
         currentForces: 10,
         capacity: 200,
       );
+      const cpu = IslandState(
+        id: 2,
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 0,
+        capacity: 200,
+      );
       final force = rules.createMovingForce(
         id: 0,
         faction: Faction.player,
@@ -930,7 +963,7 @@ void main() {
       final state = GameState(
         phase: GamePhase.playing,
         elapsedMs: 0,
-        islands: [source, target],
+        islands: [source, target, cpu],
         movingForces: [force],
       );
 
@@ -944,7 +977,7 @@ void main() {
 
       final atArrival = rules.tick(beforeArrival, deltaMs: 1);
       expect(atArrival.movingForces, isEmpty);
-      expect(atArrival.islands.last.currentForces, 30);
+      expect(atArrival.islands[1].currentForces, 30);
     },
   );
 
@@ -1017,6 +1050,595 @@ void main() {
       expect(next.selectedIslandId, 2);
     },
   );
+
+  test(
+    'reinforcement adds arrival strength and clamps every island capacity',
+    () {
+      const source = IslandState(
+        id: 0,
+        position: IslandPosition(x: -1, y: 0),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 100,
+        capacity: 200,
+      );
+      const enemy = IslandState(
+        id: 99,
+        position: IslandPosition(x: 1, y: 1),
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 100,
+        capacity: 200,
+      );
+
+      for (final size in IslandSize.values) {
+        final current = size.capacity - 1;
+        final target = IslandState(
+          id: 1,
+          position: const IslandPosition(x: 1, y: 0),
+          faction: Faction.player,
+          size: size,
+          currentForces: current,
+          capacity: size.capacity,
+        );
+        final force = MovingForce(
+          id: size.index,
+          faction: Faction.player,
+          sourceIslandId: source.id,
+          destinationIslandId: target.id,
+          strength: 1,
+          departureTimeMs: 0,
+          arrivalTimeMs: 0,
+          durationMs: 1,
+        );
+        final next = rules.tick(
+          GameState(
+            phase: GamePhase.playing,
+            elapsedMs: 0,
+            islands: [source, target, enemy],
+            movingForces: [force],
+          ),
+          deltaMs: 0,
+        );
+        expect(next.islands[1].currentForces, size.capacity);
+        expect(next.islands[1].faction, Faction.player);
+        expect(next.movingForces, isEmpty);
+      }
+
+      const atCapacity = IslandState(
+        id: 1,
+        position: IslandPosition(x: 1, y: 0),
+        faction: Faction.player,
+        size: IslandSize.small,
+        currentForces: 50,
+        capacity: 50,
+      );
+      final discarded = rules.tick(
+        GameState(
+          phase: GamePhase.playing,
+          elapsedMs: 0,
+          islands: const [source, atCapacity, enemy],
+          movingForces: const [
+            MovingForce(
+              id: 20,
+              faction: Faction.player,
+              sourceIslandId: 0,
+              destinationIslandId: 1,
+              strength: 20,
+              arrivalTimeMs: 0,
+              durationMs: 1,
+            ),
+          ],
+        ),
+        deltaMs: 0,
+      );
+      expect(discarded.islands[1].currentForces, 50);
+    },
+  );
+
+  test('neutral attacks persist damage and capture only above durability', () {
+    const neutral = IslandState(
+      id: 1,
+      position: const IslandPosition(x: 1, y: 0),
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+      capacity: 50,
+    );
+    const player = IslandState(
+      id: 0,
+      position: const IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    const enemy = IslandState(
+      id: 2,
+      position: const IslandPosition(x: 0, y: 1),
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+
+    GameState attack(int strength, IslandState target) {
+      return GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: [player, target, enemy],
+        movingForces: [
+          MovingForce(
+            id: strength,
+            faction: Faction.player,
+            sourceIslandId: player.id,
+            destinationIslandId: target.id,
+            strength: strength,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      );
+    }
+
+    final below = rules.tick(attack(4, neutral), deltaMs: 0);
+    expect(below.islands[1].faction, Faction.neutral);
+    expect(below.islands[1].durability, 6);
+    expect(below.islands[1].currentForces, 0);
+
+    final equal = rules.tick(attack(10, neutral), deltaMs: 0);
+    expect(equal.islands[1].faction, Faction.neutral);
+    expect(equal.islands[1].durability, 0);
+
+    final damagedThenCaptured = rules.tick(
+      attack(7, below.islands[1]),
+      deltaMs: 0,
+    );
+    expect(damagedThenCaptured.islands[1].faction, Faction.player);
+    expect(damagedThenCaptured.islands[1].currentForces, 1);
+    expect(damagedThenCaptured.islands[1].durability, 0);
+  });
+
+  test('enemy attacks retain defenders on below and equal values', () {
+    const player = IslandState(
+      id: 0,
+      position: IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    const enemy = IslandState(
+      id: 2,
+      position: IslandPosition(x: 0, y: 1),
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    final target = IslandState(
+      id: 1,
+      position: const IslandPosition(x: 1, y: 0),
+      faction: Faction.cpu,
+      size: IslandSize.medium,
+      currentForces: 10,
+      capacity: 100,
+    );
+
+    GameState attack(int strength) {
+      return GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: [player, target, enemy],
+        movingForces: [
+          MovingForce(
+            id: strength,
+            faction: Faction.player,
+            sourceIslandId: player.id,
+            destinationIslandId: target.id,
+            strength: strength,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      );
+    }
+
+    final below = rules.tick(attack(4), deltaMs: 0);
+    expect(below.islands[1].faction, Faction.cpu);
+    expect(below.islands[1].currentForces, 6);
+
+    final equal = rules.tick(attack(10), deltaMs: 0);
+    expect(equal.islands[1].faction, Faction.cpu);
+    expect(equal.islands[1].currentForces, 0);
+
+    final captured = rules.tick(attack(12), deltaMs: 0);
+    expect(captured.islands[1].faction, Faction.player);
+    expect(captured.islands[1].currentForces, 2);
+  });
+
+  test('post-capture survivors are clamped to the target capacity', () {
+    const player = IslandState(
+      id: 0,
+      position: IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    const neutral = IslandState(
+      id: 1,
+      position: IslandPosition(x: 1, y: 0),
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+      capacity: 50,
+    );
+    const enemy = IslandState(
+      id: 2,
+      position: IslandPosition(x: 0, y: 1),
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    final next = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: const [player, neutral, enemy],
+        movingForces: const [
+          MovingForce(
+            id: 0,
+            faction: Faction.player,
+            sourceIslandId: 0,
+            destinationIslandId: 1,
+            strength: 100,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      ),
+      deltaMs: 0,
+    );
+    expect(next.islands[1].faction, Faction.player);
+    expect(next.islands[1].currentForces, 50);
+  });
+
+  test('simultaneous arrivals cancel by faction before resolving a target', () {
+    const target = IslandState(
+      id: 2,
+      position: const IslandPosition(x: 0, y: 0),
+      faction: Faction.neutral,
+      size: IslandSize.medium,
+      durability: 10,
+      capacity: 100,
+    );
+    const player = IslandState(
+      id: 0,
+      position: const IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    const cpu = IslandState(
+      id: 1,
+      position: const IslandPosition(x: 1, y: 0),
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+
+    GameState simultaneous(int playerStrength, int cpuStrength) {
+      return GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: [player, cpu, target],
+        movingForces: [
+          MovingForce(
+            id: 0,
+            faction: Faction.player,
+            sourceIslandId: player.id,
+            destinationIslandId: target.id,
+            strength: playerStrength,
+            arrivalTimeMs: 1000,
+            durationMs: 1,
+          ),
+          MovingForce(
+            id: 1,
+            faction: Faction.cpu,
+            sourceIslandId: cpu.id,
+            destinationIslandId: target.id,
+            strength: cpuStrength,
+            arrivalTimeMs: 1000,
+            durationMs: 1,
+          ),
+        ],
+      );
+    }
+
+    final playerWins = rules.tick(simultaneous(8, 5), deltaMs: 1000);
+    expect(playerWins.islands[2].faction, Faction.neutral);
+    expect(playerWins.islands[2].durability, 7);
+
+    final cpuWins = rules.tick(simultaneous(5, 20), deltaMs: 1000);
+    expect(cpuWins.islands[2].faction, Faction.cpu);
+    expect(cpuWins.islands[2].currentForces, 5);
+    expect(cpuWins.islands[2].durability, 0);
+
+    final equal = rules.tick(simultaneous(8, 8), deltaMs: 1000);
+    expect(equal.islands[2], target);
+  });
+
+  test('growth is applied before an arrival at the same timestamp', () {
+    const player = IslandState(
+      id: 0,
+      position: IslandPosition(x: -1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 10,
+      capacity: 200,
+    );
+    const target = IslandState(
+      id: 1,
+      position: IslandPosition(x: 1, y: 0),
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 10,
+      capacity: 50,
+    );
+    const enemy = IslandState(
+      id: 2,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    final next = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: const [player, target, enemy],
+        movingForces: const [
+          MovingForce(
+            id: 0,
+            faction: Faction.player,
+            sourceIslandId: 0,
+            destinationIslandId: 1,
+            strength: 5,
+            arrivalTimeMs: 1000,
+            durationMs: 1000,
+          ),
+        ],
+      ),
+      deltaMs: 1000,
+    );
+    expect(next.islands[1].currentForces, 16);
+  });
+
+  test('result requires no owned islands and no troops in transit', () {
+    const playerIsland = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 1,
+      capacity: 50,
+    );
+    const cpuIsland = IslandState(
+      id: 1,
+      faction: Faction.cpu,
+      size: IslandSize.small,
+      currentForces: 1,
+      capacity: 50,
+    );
+
+    final defeat = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 12,
+        islands: [playerIsland, cpuIsland],
+        movingForces: const [
+          MovingForce(
+            id: 0,
+            faction: Faction.cpu,
+            sourceIslandId: 1,
+            destinationIslandId: 0,
+            strength: 2,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      ),
+      deltaMs: 0,
+    );
+    expect(defeat.phase, GamePhase.result);
+    expect(defeat.result?.type, GameResultType.defeat);
+    expect(defeat.result?.winner, Faction.cpu);
+
+    final victory = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 12,
+        islands: [playerIsland, cpuIsland],
+        movingForces: const [
+          MovingForce(
+            id: 1,
+            faction: Faction.player,
+            sourceIslandId: 0,
+            destinationIslandId: 1,
+            strength: 2,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      ),
+      deltaMs: 0,
+    );
+    expect(victory.phase, GamePhase.result);
+    expect(victory.result?.type, GameResultType.victory);
+    expect(victory.result?.winner, Faction.player);
+
+    final draw = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 12,
+        islands: const [
+          IslandState(
+            id: 2,
+            faction: Faction.neutral,
+            size: IslandSize.small,
+            durability: 10,
+          ),
+        ],
+        movingForces: const [
+          MovingForce(
+            id: 2,
+            faction: Faction.player,
+            sourceIslandId: 0,
+            destinationIslandId: 2,
+            strength: 5,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+          MovingForce(
+            id: 3,
+            faction: Faction.cpu,
+            sourceIslandId: 1,
+            destinationIslandId: 2,
+            strength: 5,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      ),
+      deltaMs: 0,
+    );
+    expect(draw.phase, GamePhase.result);
+    expect(draw.result?.type, GameResultType.draw);
+  });
+
+  test('an in-transit troop can recapture after the final island is lost', () {
+    const cpu = IslandState(
+      id: 1,
+      position: IslandPosition(x: 1, y: 0),
+      faction: Faction.cpu,
+      size: IslandSize.small,
+      currentForces: 1,
+      capacity: 50,
+    );
+    const playerForce = MovingForce(
+      id: 0,
+      faction: Faction.player,
+      sourceIslandId: 0,
+      destinationIslandId: 1,
+      strength: 2,
+      arrivalTimeMs: 100,
+      durationMs: 100,
+    );
+    final inTransit = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: const [cpu],
+        movingForces: const [playerForce],
+      ),
+      deltaMs: 50,
+    );
+    expect(inTransit.phase, GamePhase.playing);
+    expect(inTransit.movingForces, hasLength(1));
+
+    final next = rules.tick(inTransit, deltaMs: 50);
+    expect(next.phase, GamePhase.result);
+    expect(next.result?.type, GameResultType.victory);
+    expect(next.islands.single.faction, Faction.player);
+    expect(next.islands.single.currentForces, 1);
+  });
+
+  test('losing the headquarters alone does not finalize the match', () {
+    const playerHeadquarters = IslandState(
+      id: 0,
+      faction: Faction.player,
+      size: IslandSize.headquarters,
+      currentForces: 1,
+      capacity: 200,
+    );
+    const playerIsland = IslandState(
+      id: 2,
+      faction: Faction.player,
+      size: IslandSize.small,
+      currentForces: 1,
+      capacity: 50,
+    );
+    const cpuHeadquarters = IslandState(
+      id: 1,
+      faction: Faction.cpu,
+      size: IslandSize.headquarters,
+      currentForces: 100,
+      capacity: 200,
+    );
+    final next = rules.tick(
+      GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        islands: const [playerHeadquarters, playerIsland, cpuHeadquarters],
+        movingForces: const [
+          MovingForce(
+            id: 0,
+            faction: Faction.cpu,
+            sourceIslandId: 1,
+            destinationIslandId: 0,
+            strength: 2,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      ),
+      deltaMs: 0,
+    );
+    expect(next.phase, GamePhase.playing);
+    expect(next.islands[0].faction, Faction.cpu);
+    expect(next.islands[1].faction, Faction.player);
+  });
+
+  test('simultaneous elimination is a draw and freezes subsequent ticks', () {
+    const target = IslandState(
+      id: 2,
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+    );
+    final initial = GameState(
+      phase: GamePhase.playing,
+      elapsedMs: 0,
+      islands: const [target],
+      movingForces: const [
+        MovingForce(
+          id: 0,
+          faction: Faction.player,
+          sourceIslandId: 0,
+          destinationIslandId: 2,
+          strength: 5,
+          arrivalTimeMs: 0,
+          durationMs: 1,
+        ),
+        MovingForce(
+          id: 1,
+          faction: Faction.cpu,
+          sourceIslandId: 1,
+          destinationIslandId: 2,
+          strength: 5,
+          arrivalTimeMs: 0,
+          durationMs: 1,
+        ),
+      ],
+    );
+    final result = rules.tick(initial, deltaMs: 0);
+    expect(result.phase, GamePhase.result);
+    expect(result.result?.type, GameResultType.draw);
+    expect(rules.tick(result, deltaMs: 5000), same(result));
+  });
 
   test(
     'invalidates a selected source when ownership or force becomes invalid',

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -1676,6 +1676,69 @@ void main() {
     },
   );
 
+  test(
+    'keeps a cleared selection cleared after later arrivals in one tick',
+    () {
+      const selected = IslandState(
+        id: 0,
+        position: IslandPosition(x: 0, y: 0),
+        faction: Faction.player,
+        size: IslandSize.small,
+        currentForces: 5,
+        capacity: 50,
+      );
+      const playerSource = IslandState(
+        id: 1,
+        position: IslandPosition(x: -1, y: 0),
+        faction: Faction.player,
+        size: IslandSize.headquarters,
+        currentForces: 50,
+        capacity: 200,
+      );
+      const cpuSource = IslandState(
+        id: 2,
+        position: IslandPosition(x: 1, y: 0),
+        faction: Faction.cpu,
+        size: IslandSize.headquarters,
+        currentForces: 50,
+        capacity: 200,
+      );
+
+      final next = rules.tick(
+        GameState(
+          phase: GamePhase.playing,
+          elapsedMs: 0,
+          selectedIslandId: selected.id,
+          islands: const [selected, playerSource, cpuSource],
+          movingForces: const [
+            MovingForce(
+              id: 0,
+              faction: Faction.cpu,
+              sourceIslandId: 2,
+              destinationIslandId: 0,
+              strength: 10,
+              arrivalTimeMs: 100,
+              durationMs: 100,
+            ),
+            MovingForce(
+              id: 1,
+              faction: Faction.player,
+              sourceIslandId: 1,
+              destinationIslandId: 0,
+              strength: 10,
+              arrivalTimeMs: 200,
+              durationMs: 200,
+            ),
+          ],
+        ),
+        deltaMs: 200,
+      );
+
+      expect(next.islands.first.faction, Faction.player);
+      expect(next.selectedIslandId, isNull);
+    },
+  );
+
   test('controller uses an injected clock with a manual loop', () {
     final clock = FixedClock();
     final loop = ManualGameLoop();


### PR DESCRIPTION
## 概要

到着部隊を時刻・対象島ごとに決定論的に一括処理し、自軍増援、中立島・敵島との戦闘、占領、勝敗確定までを一つのゲームルールとして実装します。

## 背景・目的

Issue #10で定義された到着イベントの処理を、到着順に依存せず、Issue #9の兵力増加優先順序を維持して解決します。本陣の有無ではなく、所有島と移動中部隊の全滅で勝敗を判定し、結果確定後はゲーム時間と状態更新を停止します。

## 対応内容

- 到着時刻と対象島が同じ部隊を陣営別に合算し、両軍分を先に相殺
- 自軍島への増援、neutral durability・敵守備兵力との戦闘、厳密な超過時だけの占領、各capacity適用
- 中立島ダメージの永続化と、同数時の所有権維持
- ゲーム内時刻順に兵力増加から到着batchを処理し、各batch完了後にだけ勝敗を評価
- 所有島と移動中部隊に基づくplayer勝利・CPU勝利・drawの確定
- 結果確定後のstate freezeとGameLoop停止
- 同一tick内の占領・再占領でも解除済みselectionを復活させない回帰保護

## 主な設計判断

- 1 tick内の到着時刻を昇順に処理し、各時刻の直前まで兵力増加を適用してIssue #9の順序を維持
- 同時到着はtargetごとにplayer/CPU totalsを算出して相殺後の一方だけを島へ適用し、collection順序の影響を排除
- 勝敗は各同時event groupの全処理後にのみ確定し、一時的な途中状態を観測しない
- selection解除を後続eventへ単調に引き継ぎ、同一tick内の再占領による復活を防止

## 受け入れ条件との対応

- [x] 自軍島への増援をcapacity内で加算
- [x] 増援・占領後残存兵力の超過分を破棄
- [x] 中立島への不足攻撃はdurabilityだけを減らし、次回攻撃まで保持
- [x] 攻撃兵力が守備値を厳密に上回る場合だけ所有権を変更
- [x] 同数では値を0にし、所有権またはneutral状態を維持
- [x] 同時到着を陣営別合算と事前相殺で解決
- [x] 兵力増加と到着が同時刻の場合はIssue #9どおり増加を先行
- [x] 最終島喪失後も自軍部隊が移動中なら試合を継続し、再占領可能
- [x] 所有島と移動中部隊がともに0の陣営を敗北として確定
- [x] 同時全滅を1回だけdrawとして確定
- [x] 本陣喪失だけでは試合を終了しない

## 検証

- `fvm dart format --output=none --set-exit-if-changed lib/game/game_controller.dart lib/game/game_rules.dart test/game_controller_test.dart test/game_rules_test.dart`: 成功
- `git diff --check origin/main...HEAD`: 成功
- `fvm flutter test test/game_rules_test.dart test/game_controller_test.dart`: 成功（55 tests）
- `fvm flutter analyze`: 成功（No issues found）
- `fvm flutter test`: 成功（全tests）

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `2bdab2776500528b8a6f09b7c1dba5137e003b39`、post-cloud roundを含む）
- GitHub Codex review（1回のみ）: 指摘対応済み（review/current HEAD: `2bdab2776500528b8a6f09b7c1dba5137e003b39`。結果画面・再戦はIssue #10の明示的対象外かつIssue #13の範囲と確認し、根拠を返信してthread resolved）
- Required checks: 対象なし（status 0件、check run 0件、workflow run 0件、main branch protectionなし）

## 残存リスク

GitHub required checksが設定されていないため、server-sideの自動検証証跡はありません。platform buildは承認済み検証項目外のため未実施です。結果画面と再戦操作は後続Issue #13で実装されるまで利用できませんが、Issue #10の承認範囲内の既知の機能リスクはありません。

Closes #10