### PR TITLE
[Game Rules] 標準難易度のCPU戦略を実装する

### DIFF
--- a/lib/game/cpu_strategy.dart
+++ b/lib/game/cpu_strategy.dart
@@ -391,6 +391,21 @@ final class CpuStrategy {
           destination: target,
           strength: strength,
         );
+        // Do not spend a fresh troop on a target that known CPU arrivals
+        // already capture by this time.  A candidate remains eligible when
+        // those arrivals alone leave the target uncaptured, so simultaneous
+        // forces are still evaluated as one arrival-time combat.
+        final predictedWithoutCandidate = forecast(
+          state,
+          atMs: candidate.arrivalTimeMs,
+        );
+        final targetWithoutCandidate = _findIsland(
+          predictedWithoutCandidate.islands,
+          target.id,
+        );
+        if (targetWithoutCandidate?.faction == Faction.cpu) {
+          continue;
+        }
         final predicted = _forecastWithCandidate(
           state,
           source: source,

--- a/lib/game/cpu_strategy.dart
+++ b/lib/game/cpu_strategy.dart
@@ -331,35 +331,41 @@ final class CpuStrategy {
     if (enemies.isEmpty) {
       return null;
     }
-    enemies.sort((first, second) {
-      final forces = first.currentForces.compareTo(second.currentForces);
-      if (forces != 0) {
-        return forces;
-      }
-      return first.id.compareTo(second.id);
-    });
-    final target = enemies.first;
-    final fallbackSources = [...sources]
-      ..sort((first, second) {
-        final forces = second.currentForces.compareTo(first.currentForces);
-        if (forces != 0) {
-          return forces;
-        }
-        final distance = _distance(
-          first,
-          target,
-        ).compareTo(_distance(second, target));
-        if (distance != 0) {
-          return distance;
-        }
-        return first.id.compareTo(second.id);
-      });
-    final source = fallbackSources.first;
+    final strongestForce = sources
+        .map((source) => source.currentForces)
+        .reduce(math.max);
+    final weakestForce = enemies
+        .map((enemy) => enemy.currentForces)
+        .reduce(math.min);
+    final fallbackCandidates =
+        [
+          for (final source in sources)
+            if (source.currentForces == strongestForce)
+              for (final target in enemies)
+                if (target.currentForces == weakestForce)
+                  _AttackCandidate(
+                    source: source,
+                    target: target,
+                    strength: source.currentForces ~/ 2,
+                    distance: _distance(source, target),
+                  ),
+        ]..sort((first, second) {
+          final distance = first.distance.compareTo(second.distance);
+          if (distance != 0) {
+            return distance;
+          }
+          final target = first.target.id.compareTo(second.target.id);
+          if (target != 0) {
+            return target;
+          }
+          return first.source.id.compareTo(second.source.id);
+        });
+    final fallback = fallbackCandidates.first;
     return CpuDecision(
       kind: CpuDecisionKind.attack,
-      sourceIslandId: source.id,
-      destinationIslandId: target.id,
-      strength: source.currentForces ~/ 2,
+      sourceIslandId: fallback.source.id,
+      destinationIslandId: fallback.target.id,
+      strength: fallback.strength,
     );
   }
 

--- a/lib/game/cpu_strategy.dart
+++ b/lib/game/cpu_strategy.dart
@@ -1,0 +1,535 @@
+import 'dart:math' as math;
+
+import 'game_rules.dart';
+import 'game_state.dart';
+
+/// The kind of action selected by the standard CPU.
+enum CpuDecisionKind { defense, attack }
+
+/// One deterministic CPU dispatch.  A decision never contains hidden
+/// strength or speed adjustments: [strength] is always the floor half of the
+/// selected source island's current forces.
+final class CpuDecision {
+  const CpuDecision({
+    required this.kind,
+    required this.sourceIslandId,
+    required this.destinationIslandId,
+    required this.strength,
+  });
+
+  final CpuDecisionKind kind;
+  final int sourceIslandId;
+  final int destinationIslandId;
+  final int strength;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CpuDecision &&
+        other.kind == kind &&
+        other.sourceIslandId == sourceIslandId &&
+        other.destinationIslandId == destinationIslandId &&
+        other.strength == strength;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(kind, sourceIslandId, destinationIslandId, strength);
+
+  @override
+  String toString() {
+    return 'CpuDecision(kind: $kind, source: $sourceIslandId, '
+        'destination: $destinationIslandId, strength: $strength)';
+  }
+}
+
+/// Standard, deterministic CPU strategy.
+///
+/// The strategy only reads the supplied [GameState].  In particular, it does
+/// not inspect future player actions or retain a hidden board model.  The
+/// random source is used solely for the next decision interval; all choices
+/// for one state are ordered by explicit, stable tie-breakers.
+final class CpuStrategy {
+  CpuStrategy({
+    math.Random? random,
+    GameRules? rules,
+    IslandMapViewport viewport = GameRules.defaultMapViewport,
+  }) : this._(
+         random: random ?? math.Random(),
+         rules: rules ?? const GameRules(),
+         viewport: viewport,
+       );
+
+  /// Creates an inert strategy for engine clients that want to exercise the
+  /// player-only loop.  Production uses the default enabled constructor; the
+  /// explicit mode keeps controller tests independent from CPU decisions.
+  CpuStrategy.noop({
+    GameRules? rules,
+    IslandMapViewport viewport = GameRules.defaultMapViewport,
+  }) : this._(
+         random: math.Random(0),
+         rules: rules ?? const GameRules(),
+         viewport: viewport,
+         enabled: false,
+       );
+
+  CpuStrategy._({
+    required this.random,
+    required this.rules,
+    required this.viewport,
+    this.enabled = true,
+  });
+
+  static const minDecisionIntervalMs = 1500;
+  static const maxDecisionIntervalMs = 3000;
+
+  final math.Random random;
+  final GameRules rules;
+  final IslandMapViewport viewport;
+  final bool enabled;
+
+  /// Returns the next interval in the inclusive [1.5, 3] second range.
+  int nextDecisionDelayMs() {
+    return minDecisionIntervalMs +
+        random.nextInt(maxDecisionIntervalMs - minDecisionIntervalMs + 1);
+  }
+
+  /// Compatibility alias for callers that describe a CPU turn as a choice.
+  CpuDecision? choose(GameState state) => decide(state);
+
+  /// Selects at most one dispatch for [state].
+  ///
+  /// Defense threats are considered first.  When no defense can arrive in
+  /// time, attack candidates follow the priority from the game rules.
+  CpuDecision? decide(GameState state) {
+    if (!enabled || state.phase != GamePhase.playing) {
+      return null;
+    }
+
+    final defense = _chooseDefense(state);
+    if (defense != null) {
+      return defense;
+    }
+    return _chooseAttack(state);
+  }
+
+  /// Applies one previously selected decision using the same dispatch and
+  /// movement rules as the player.  Invalid or stale decisions are ignored.
+  GameState applyDecision(
+    GameState state,
+    CpuDecision decision, {
+    int? movingForceId,
+  }) {
+    if (state.phase != GamePhase.playing || decision.strength <= 0) {
+      return state;
+    }
+    final sourceIndex = state.islands.indexWhere(
+      (island) => island.id == decision.sourceIslandId,
+    );
+    final destinationIndex = state.islands.indexWhere(
+      (island) => island.id == decision.destinationIslandId,
+    );
+    if (sourceIndex < 0 ||
+        destinationIndex < 0 ||
+        sourceIndex == destinationIndex) {
+      return state;
+    }
+
+    final source = state.islands[sourceIndex];
+    final destination = state.islands[destinationIndex];
+    final expectedStrength = source.currentForces ~/ 2;
+    if (source.faction != Faction.cpu ||
+        expectedStrength <= 0 ||
+        decision.strength != expectedStrength) {
+      return state;
+    }
+
+    final islands = [...state.islands];
+    islands[sourceIndex] = source.copyWith(
+      currentForces: source.currentForces - expectedStrength,
+    );
+    final force = rules.createMovingForce(
+      id: movingForceId ?? _nextMovingForceId(state),
+      faction: Faction.cpu,
+      source: source,
+      destination: destination,
+      strength: expectedStrength,
+      departureTimeMs: state.elapsedMs,
+      viewport: viewport,
+    );
+    return state.copyWith(
+      islands: islands,
+      movingForces: [...state.movingForces, force],
+    );
+  }
+
+  /// Compatibility alias for dispatch-oriented callers.
+  GameState dispatch(
+    GameState state,
+    CpuDecision decision, {
+    int? movingForceId,
+  }) {
+    return applyDecision(state, decision, movingForceId: movingForceId);
+  }
+
+  /// Predicts the state at a known future timestamp using only already-known
+  /// moving forces and the optional candidate force.
+  GameState forecast(
+    GameState state, {
+    required int atMs,
+    MovingForce? additionalForce,
+  }) {
+    if (atMs < state.elapsedMs) {
+      return state;
+    }
+    final movingForces = additionalForce == null
+        ? state.movingForces
+        : [...state.movingForces, additionalForce];
+    return rules.tick(
+      state.copyWith(movingForces: movingForces),
+      deltaMs: atMs - state.elapsedMs,
+    );
+  }
+
+  CpuDecision? _chooseDefense(GameState state) {
+    final threats = <_Threat>[];
+    for (final force in state.movingForces) {
+      if (force.faction != Faction.player ||
+          force.strength <= 0 ||
+          force.arrivalTimeMs <= state.elapsedMs) {
+        continue;
+      }
+      final target = _findIsland(state.islands, force.destinationIslandId);
+      if (target?.faction != Faction.cpu) {
+        continue;
+      }
+      final predicted = forecast(state, atMs: force.arrivalTimeMs);
+      final predictedTarget = _findIsland(
+        predicted.islands,
+        force.destinationIslandId,
+      );
+      if (predictedTarget?.faction != Faction.cpu) {
+        threats.add(
+          _Threat(
+            arrivalTimeMs: force.arrivalTimeMs,
+            destinationIslandId: force.destinationIslandId,
+            forceId: force.id,
+          ),
+        );
+      }
+    }
+
+    threats.sort((first, second) {
+      final arrival = first.arrivalTimeMs.compareTo(second.arrivalTimeMs);
+      if (arrival != 0) {
+        return arrival;
+      }
+      final target = first.destinationIslandId.compareTo(
+        second.destinationIslandId,
+      );
+      if (target != 0) {
+        return target;
+      }
+      return first.forceId.compareTo(second.forceId);
+    });
+
+    final cpuIslands = state.islands
+        .where(
+          (island) => island.faction == Faction.cpu && island.currentForces > 1,
+        )
+        .toList();
+    for (final threat in threats) {
+      final target = _findIsland(state.islands, threat.destinationIslandId);
+      if (target == null) {
+        continue;
+      }
+      final sources = cpuIslands
+          .where((island) => island.id != target.id)
+          .toList();
+      sources.sort((first, second) {
+        final firstDistance = _distance(first, target);
+        final secondDistance = _distance(second, target);
+        final distance = firstDistance.compareTo(secondDistance);
+        if (distance != 0) {
+          return distance;
+        }
+        final forces = first.currentForces.compareTo(second.currentForces);
+        if (forces != 0) {
+          return forces;
+        }
+        return first.id.compareTo(second.id);
+      });
+
+      for (final source in sources) {
+        final strength = source.currentForces ~/ 2;
+        if (strength <= 0) {
+          continue;
+        }
+        final candidate = _candidateForce(
+          state,
+          source: source,
+          destination: target,
+          strength: strength,
+        );
+        if (candidate.arrivalTimeMs > threat.arrivalTimeMs) {
+          continue;
+        }
+        final predicted = _forecastWithCandidate(
+          state,
+          source: source,
+          candidate: candidate,
+          atMs: threat.arrivalTimeMs,
+        );
+        final predictedTarget = _findIsland(predicted.islands, target.id);
+        if (predictedTarget?.faction == Faction.cpu) {
+          return CpuDecision(
+            kind: CpuDecisionKind.defense,
+            sourceIslandId: source.id,
+            destinationIslandId: target.id,
+            strength: strength,
+          );
+        }
+      }
+    }
+    return null;
+  }
+
+  CpuDecision? _chooseAttack(GameState state) {
+    final sources = state.islands
+        .where(
+          (island) => island.faction == Faction.cpu && island.currentForces > 1,
+        )
+        .toList();
+    if (sources.isEmpty) {
+      return null;
+    }
+
+    final enemies = state.islands
+        .where((island) => island.faction == Faction.player)
+        .toList();
+    final neutrals = state.islands
+        .where((island) => island.faction == Faction.neutral)
+        .toList();
+
+    final enemyCandidates = _capturableCandidates(
+      state,
+      sources: sources,
+      targets: enemies,
+    );
+    if (enemyCandidates.isNotEmpty) {
+      return _selectAttackCandidate(enemyCandidates);
+    }
+
+    final neutralCandidates = _capturableCandidates(
+      state,
+      sources: sources,
+      targets: neutrals,
+    );
+    if (neutralCandidates.isNotEmpty) {
+      return _selectAttackCandidate(neutralCandidates);
+    }
+
+    if (enemies.isEmpty) {
+      return null;
+    }
+    enemies.sort((first, second) {
+      final forces = first.currentForces.compareTo(second.currentForces);
+      if (forces != 0) {
+        return forces;
+      }
+      return first.id.compareTo(second.id);
+    });
+    final target = enemies.first;
+    final fallbackSources = [...sources]
+      ..sort((first, second) {
+        final forces = second.currentForces.compareTo(first.currentForces);
+        if (forces != 0) {
+          return forces;
+        }
+        final distance = _distance(
+          first,
+          target,
+        ).compareTo(_distance(second, target));
+        if (distance != 0) {
+          return distance;
+        }
+        return first.id.compareTo(second.id);
+      });
+    final source = fallbackSources.first;
+    return CpuDecision(
+      kind: CpuDecisionKind.attack,
+      sourceIslandId: source.id,
+      destinationIslandId: target.id,
+      strength: source.currentForces ~/ 2,
+    );
+  }
+
+  List<_AttackCandidate> _capturableCandidates(
+    GameState state, {
+    required List<IslandState> sources,
+    required List<IslandState> targets,
+  }) {
+    final candidates = <_AttackCandidate>[];
+    for (final target in targets) {
+      final sourceCandidates = <_AttackCandidate>[];
+      for (final source in sources) {
+        if (source.id == target.id) {
+          continue;
+        }
+        final strength = source.currentForces ~/ 2;
+        if (strength <= 0) {
+          continue;
+        }
+        final candidate = _candidateForce(
+          state,
+          source: source,
+          destination: target,
+          strength: strength,
+        );
+        final predicted = _forecastWithCandidate(
+          state,
+          source: source,
+          candidate: candidate,
+          atMs: candidate.arrivalTimeMs,
+        );
+        final predictedTarget = _findIsland(predicted.islands, target.id);
+        if (predictedTarget?.faction == Faction.cpu) {
+          sourceCandidates.add(
+            _AttackCandidate(
+              source: source,
+              target: target,
+              strength: strength,
+              distance: _distance(source, target),
+            ),
+          );
+        }
+      }
+      if (sourceCandidates.isNotEmpty) {
+        sourceCandidates.sort(_compareSourcePriority);
+        candidates.add(sourceCandidates.first);
+      }
+    }
+    return candidates;
+  }
+
+  CpuDecision _selectAttackCandidate(List<_AttackCandidate> candidates) {
+    candidates.sort((first, second) {
+      final distance = first.distance.compareTo(second.distance);
+      if (distance != 0) {
+        return distance;
+      }
+      final target = first.target.id.compareTo(second.target.id);
+      if (target != 0) {
+        return target;
+      }
+      return _compareSourcePriority(first, second);
+    });
+    final selected = candidates.first;
+    return CpuDecision(
+      kind: CpuDecisionKind.attack,
+      sourceIslandId: selected.source.id,
+      destinationIslandId: selected.target.id,
+      strength: selected.strength,
+    );
+  }
+
+  int _compareSourcePriority(_AttackCandidate first, _AttackCandidate second) {
+    final forces = first.source.currentForces.compareTo(
+      second.source.currentForces,
+    );
+    if (forces != 0) {
+      return forces;
+    }
+    final distance = first.distance.compareTo(second.distance);
+    if (distance != 0) {
+      return distance;
+    }
+    return first.source.id.compareTo(second.source.id);
+  }
+
+  MovingForce _candidateForce(
+    GameState state, {
+    required IslandState source,
+    required IslandState destination,
+    required int strength,
+  }) {
+    return rules.createMovingForce(
+      id: _nextMovingForceId(state),
+      faction: Faction.cpu,
+      source: source,
+      destination: destination,
+      strength: strength,
+      departureTimeMs: state.elapsedMs,
+      viewport: viewport,
+    );
+  }
+
+  GameState _forecastWithCandidate(
+    GameState state, {
+    required IslandState source,
+    required MovingForce candidate,
+    required int atMs,
+  }) {
+    final sourceIndex = state.islands.indexWhere(
+      (island) => island.id == source.id,
+    );
+    if (sourceIndex < 0) {
+      return state;
+    }
+    final islands = [...state.islands];
+    islands[sourceIndex] = source.copyWith(
+      currentForces: source.currentForces - candidate.strength,
+    );
+    return forecast(
+      state.copyWith(islands: islands),
+      atMs: atMs,
+      additionalForce: candidate,
+    );
+  }
+
+  double _distance(IslandState first, IslandState second) {
+    return viewport.movingForceDistance(first.position, second.position);
+  }
+
+  static IslandState? _findIsland(List<IslandState> islands, int id) {
+    for (final island in islands) {
+      if (island.id == id) {
+        return island;
+      }
+    }
+    return null;
+  }
+
+  static int _nextMovingForceId(GameState state) {
+    var maxId = -1;
+    for (final force in state.movingForces) {
+      maxId = math.max(maxId, force.id);
+    }
+    return maxId + 1;
+  }
+}
+
+final class _Threat {
+  const _Threat({
+    required this.arrivalTimeMs,
+    required this.destinationIslandId,
+    required this.forceId,
+  });
+
+  final int arrivalTimeMs;
+  final int destinationIslandId;
+  final int forceId;
+}
+
+final class _AttackCandidate {
+  const _AttackCandidate({
+    required this.source,
+    required this.target,
+    required this.strength,
+    required this.distance,
+  });
+
+  final IslandState source;
+  final IslandState target;
+  final int strength;
+  final double distance;
+}

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'cpu_strategy.dart';
 import 'game_loop.dart';
 import 'game_rules.dart';
 import 'game_state.dart';
@@ -27,15 +28,27 @@ final mapViewportProvider = Provider<IslandMapViewport>(
   (ref) => GameRules.defaultMapViewport,
 );
 
+/// The standard CPU is injectable as a whole so deterministic tests can use
+/// a seeded strategy or a no-op strategy without changing the game engine.
+final cpuStrategyProvider = Provider<CpuStrategy>((ref) {
+  return CpuStrategy(
+    random: ref.read(randomProvider),
+    rules: ref.read(gameRulesProvider),
+    viewport: ref.watch(mapViewportProvider),
+  );
+});
+
 @riverpod
 class GameController extends _$GameController {
   late GameLoop _gameLoop;
   late Random _random;
   late GameClock _clock;
   late GameRules _rules;
+  late CpuStrategy _cpuStrategy;
 
   var _disposed = false;
   int? _lastTickMs;
+  int? _nextCpuDecisionAtMs;
   IslandMapViewport? _cachedViewport;
   GameConfiguration? _cachedConfiguration;
   GameState? _cachedInitialState;
@@ -50,6 +63,7 @@ class GameController extends _$GameController {
     _random = ref.read(randomProvider);
     _clock = ref.read(gameClockProvider);
     _rules = ref.read(gameRulesProvider);
+    _cpuStrategy = ref.read(cpuStrategyProvider);
     final viewport = ref.watch(mapViewportProvider);
     final providerConfiguration = ref.read(gameConfigurationProvider);
     ref.onDispose(() {
@@ -95,12 +109,16 @@ class GameController extends _$GameController {
       return;
     }
 
+    final wasPaused = state.phase == GamePhase.paused;
     // Preserve the existing tap-to-play behavior.  Consumers that need a
     // visible countdown can apply GameRules.tick to the same state instead.
     state = nextState.copyWith(
       phase: GamePhase.playing,
       countdownRemainingMs: 0,
     );
+    if (!wasPaused || _nextCpuDecisionAtMs == null) {
+      _scheduleNextCpuDecision();
+    }
     _lastTickMs = _clock.nowMs();
     _gameLoop.start(_tick);
   }
@@ -127,6 +145,12 @@ class GameController extends _$GameController {
       phase: GamePhase.playing,
       countdownRemainingMs: 0,
     );
+    // Game time is frozen while paused, so preserve the pending judgment's
+    // absolute game-time deadline across resume.  A null deadline only occurs
+    // after a rebuilt controller and needs a fresh injected interval.
+    if (_nextCpuDecisionAtMs == null) {
+      _scheduleNextCpuDecision();
+    }
     _lastTickMs = _clock.nowMs();
     _gameLoop.start(_tick);
   }
@@ -278,10 +302,42 @@ class GameController extends _$GameController {
     final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
     final nextState = _rules.tick(state, deltaMs: deltaMs);
     state = nextState;
+    if (state.phase == GamePhase.playing) {
+      _runCpuDecisionIfDue();
+    }
     if (nextState.phase == GamePhase.result) {
       _gameLoop.stop();
       _lastTickMs = null;
+      _nextCpuDecisionAtMs = null;
     }
+  }
+
+  void _scheduleNextCpuDecision() {
+    _nextCpuDecisionAtMs = state.elapsedMs + _cpuStrategy.nextDecisionDelayMs();
+  }
+
+  void _runCpuDecisionIfDue() {
+    final nextDecisionAtMs = _nextCpuDecisionAtMs;
+    if (nextDecisionAtMs == null) {
+      _scheduleNextCpuDecision();
+      return;
+    }
+    if (state.elapsedMs < nextDecisionAtMs) {
+      return;
+    }
+
+    final decision = _cpuStrategy.decide(state);
+    if (decision != null) {
+      state = _cpuStrategy.applyDecision(
+        state,
+        decision,
+        movingForceId: _nextMovingForceId,
+      );
+    }
+    // Schedule from the current game time rather than catching up missed
+    // wall-clock callbacks.  This keeps every interval in the documented
+    // range and still makes one judgment produce at most one troop.
+    _scheduleNextCpuDecision();
   }
 
   IslandState? _findIsland(int id) {

--- a/test/cpu_controller_integration_test.dart
+++ b/test/cpu_controller_integration_test.dart
@@ -1,0 +1,102 @@
+import 'dart:math';
+
+import 'package:conquest/game/cpu_strategy.dart';
+import 'package:conquest/game/game_controller.dart';
+import 'package:conquest/game/game_loop.dart';
+import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/game/game_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class ZeroRandom implements Random {
+  @override
+  bool nextBool() => false;
+
+  @override
+  double nextDouble() => 0;
+
+  @override
+  int nextInt(int max) => 0;
+}
+
+void main() {
+  late ManualGameLoop loop;
+  late ProviderContainer container;
+
+  setUp(() {
+    loop = ManualGameLoop();
+    container = ProviderContainer(
+      overrides: [
+        gameLoopProvider.overrideWithValue(loop),
+        randomProvider.overrideWithValue(Random(7)),
+        cpuStrategyProvider.overrideWithValue(
+          CpuStrategy(
+            random: ZeroRandom(),
+            viewport: GameRules.defaultMapViewport,
+          ),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  test('dispatches at most one CPU troop per due judgment', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+
+    for (var index = 0; index < 29; index++) {
+      loop.tick();
+    }
+    expect(
+      container
+          .read(gameControllerProvider)
+          .movingForces
+          .where((force) => force.faction == Faction.cpu),
+      isEmpty,
+    );
+
+    loop.tick();
+    final firstDue = container.read(gameControllerProvider);
+    expect(
+      firstDue.movingForces.where((force) => force.faction == Faction.cpu),
+      hasLength(1),
+    );
+
+    loop.tick();
+    expect(
+      container
+          .read(gameControllerProvider)
+          .movingForces
+          .where((force) => force.faction == Faction.cpu),
+      hasLength(1),
+    );
+  });
+
+  test('does not decide during a countdown or after pausing', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    controller.state = container
+        .read(gameControllerProvider)
+        .copyWith(phase: GamePhase.startCountdown, countdownRemainingMs: 1000);
+
+    for (var index = 0; index < 20; index++) {
+      loop.tick();
+    }
+    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
+    expect(
+      container
+          .read(gameControllerProvider)
+          .movingForces
+          .where((force) => force.faction == Faction.cpu),
+      isEmpty,
+    );
+
+    controller.pauseGame();
+    final paused = container.read(gameControllerProvider);
+    expect(paused.phase, GamePhase.paused);
+    expect(loop.isRunning, isFalse);
+    loop.tick();
+    expect(container.read(gameControllerProvider), paused);
+  });
+}

--- a/test/cpu_strategy_test.dart
+++ b/test/cpu_strategy_test.dart
@@ -1,0 +1,247 @@
+import 'dart:math';
+
+import 'package:conquest/game/cpu_strategy.dart';
+import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/game/game_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _viewport = IslandMapViewport(width: 320, height: 320);
+
+IslandState _island({
+  required int id,
+  required Faction faction,
+  required int forces,
+  double x = 0,
+  double y = 0,
+  int? durability,
+  int capacity = 200,
+  IslandSize size = IslandSize.headquarters,
+}) {
+  return IslandState(
+    id: id,
+    position: IslandPosition(x: x, y: y),
+    faction: faction,
+    size: size,
+    currentForces: forces,
+    durability: durability ?? (faction == Faction.neutral ? forces : 0),
+    capacity: capacity,
+  );
+}
+
+GameState _playing({
+  required List<IslandState> islands,
+  List<MovingForce> movingForces = const [],
+  int elapsedMs = 0,
+}) {
+  return GameState(
+    phase: GamePhase.playing,
+    elapsedMs: elapsedMs,
+    islands: islands,
+    movingForces: movingForces,
+  );
+}
+
+void main() {
+  test('decision delays stay within the inclusive 1.5 to 3 second range', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+
+    final delays = [
+      for (var index = 0; index < 100; index++) strategy.nextDecisionDelayMs(),
+    ];
+
+    expect(delays, everyElement(inInclusiveRange(1500, 3000)));
+  });
+
+  test('defense has priority when a nearby reinforcement prevents capture', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20, x: -0.2, y: -0.2),
+        _island(id: 2, faction: Faction.cpu, forces: 5, x: 0, y: 0),
+        _island(id: 3, faction: Faction.player, forces: 100, x: 0.8, y: 0.8),
+      ],
+      movingForces: [
+        MovingForce(
+          id: 8,
+          faction: Faction.player,
+          sourceIslandId: 3,
+          destinationIslandId: 2,
+          strength: 10,
+          departureTimeMs: 0,
+          arrivalTimeMs: 1000,
+          durationMs: 1000,
+        ),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.kind, CpuDecisionKind.defense);
+    expect(decision.sourceIslandId, 1);
+    expect(decision.destinationIslandId, 2);
+    expect(decision.strength, 10);
+  });
+
+  test('falls back to an attack when defense cannot prevent capture', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 4, x: -0.2, y: -0.2),
+        _island(id: 2, faction: Faction.cpu, forces: 5, x: 0, y: 0),
+        _island(id: 3, faction: Faction.player, forces: 100, x: 0.8, y: 0.8),
+        _island(id: 4, faction: Faction.player, forces: 10, x: 0.4, y: 0.4),
+      ],
+      movingForces: [
+        MovingForce(
+          id: 8,
+          faction: Faction.player,
+          sourceIslandId: 3,
+          destinationIslandId: 2,
+          strength: 10,
+          departureTimeMs: 0,
+          arrivalTimeMs: 1000,
+          durationMs: 1000,
+        ),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.kind, CpuDecisionKind.attack);
+    expect(decision.destinationIslandId, 4);
+  });
+
+  test('prefers capturable enemy islands before neutral islands', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20, x: -0.8, y: -0.8),
+        _island(id: 2, faction: Faction.player, forces: 4, x: 0.2, y: 0.2),
+        _island(
+          id: 3,
+          faction: Faction.neutral,
+          forces: 3,
+          durability: 3,
+          x: 0.1,
+          y: 0.1,
+          size: IslandSize.small,
+          capacity: 50,
+        ),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.destinationIslandId, 2);
+  });
+
+  test('chooses the least-force sufficient source, then the nearer source', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20, x: -0.7, y: -0.7),
+        _island(id: 2, faction: Faction.cpu, forces: 24, x: 0.1, y: 0.1),
+        _island(id: 3, faction: Faction.player, forces: 10, x: 0.2, y: 0.2),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.sourceIslandId, 2);
+
+    final equalForceState = state.copyWith(
+      islands: [
+        for (final island in state.islands)
+          island.id == 1
+              ? island.copyWith(
+                  currentForces: 24,
+                  position: const IslandPosition(x: -0.8, y: -0.8),
+                )
+              : island,
+      ],
+    );
+    final nearerDecision = strategy.decide(equalForceState);
+    expect(nearerDecision!.sourceIslandId, 2);
+  });
+
+  test(
+    'uses the weakest enemy and strongest source when no capture is possible',
+    () {
+      final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+      final state = _playing(
+        islands: [
+          _island(id: 1, faction: Faction.cpu, forces: 20, x: -0.8, y: -0.8),
+          _island(id: 2, faction: Faction.cpu, forces: 40, x: 0.8, y: 0.8),
+          _island(id: 3, faction: Faction.player, forces: 100, x: 0.2, y: 0.2),
+          _island(id: 4, faction: Faction.player, forces: 101, x: 0.3, y: 0.3),
+        ],
+      );
+
+      final decision = strategy.decide(state);
+
+      expect(decision, isNotNull);
+      expect(decision!.sourceIslandId, 2);
+      expect(decision.destinationIslandId, 3);
+      expect(decision.strength, 20);
+    },
+  );
+
+  test('applies exactly one CPU dispatch without changing its abilities', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20, x: -0.5, y: -0.5),
+        _island(id: 2, faction: Faction.player, forces: 5, x: 0.5, y: 0.5),
+      ],
+    );
+    final decision = strategy.decide(state)!;
+
+    final next = strategy.applyDecision(state, decision);
+
+    expect(next.movingForces, hasLength(1));
+    expect(next.movingForces.single.faction, Faction.cpu);
+    expect(next.movingForces.single.strength, 10);
+    expect(next.islands.first.currentForces, 10);
+  });
+
+  test('does not decide outside the playing phase', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20),
+        _island(id: 2, faction: Faction.player, forces: 5, x: 0.5, y: 0.5),
+      ],
+    );
+
+    for (final phase in [
+      GamePhase.configuration,
+      GamePhase.startCountdown,
+      GamePhase.paused,
+      GamePhase.resumeCountdown,
+      GamePhase.result,
+    ]) {
+      final nonPlaying = phase == GamePhase.result
+          ? state.finishWithResult(const GameResult.draw(elapsedMs: 0))
+          : state.copyWith(phase: phase);
+      expect(strategy.decide(nonPlaying), isNull, reason: '$phase');
+    }
+  });
+
+  test('same seed and state reproduce delays and decisions', () {
+    final first = CpuStrategy(random: Random(42), viewport: _viewport);
+    final second = CpuStrategy(random: Random(42), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20),
+        _island(id: 2, faction: Faction.player, forces: 5, x: 0.5, y: 0.5),
+      ],
+    );
+
+    expect(first.nextDecisionDelayMs(), second.nextDecisionDelayMs());
+    expect(first.decide(state), second.decide(state));
+  });
+}

--- a/test/cpu_strategy_test.dart
+++ b/test/cpu_strategy_test.dart
@@ -138,6 +138,35 @@ void main() {
     expect(decision!.destinationIslandId, 2);
   });
 
+  test('does not reprioritize an enemy already captured by a CPU troop', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 20, x: 0, y: 0),
+        _island(id: 4, faction: Faction.cpu, forces: 20, x: 0.2, y: 0.2),
+        _island(id: 2, faction: Faction.player, forces: 10, x: 0.1, y: 0.1),
+        _island(id: 3, faction: Faction.player, forces: 4, x: 0.8, y: 0.8),
+      ],
+      movingForces: [
+        MovingForce(
+          id: 90,
+          faction: Faction.cpu,
+          sourceIslandId: 4,
+          destinationIslandId: 2,
+          strength: 20,
+          departureTimeMs: 0,
+          arrivalTimeMs: 100,
+          durationMs: 100,
+        ),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.destinationIslandId, 3);
+  });
+
   test('chooses the least-force sufficient source, then the nearer source', () {
     final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
     final state = _playing(

--- a/test/cpu_strategy_test.dart
+++ b/test/cpu_strategy_test.dart
@@ -190,6 +190,22 @@ void main() {
     },
   );
 
+  test('uses distance before id for equally weak fallback enemies', () {
+    final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
+    final state = _playing(
+      islands: [
+        _island(id: 1, faction: Faction.cpu, forces: 40, x: 0, y: 0),
+        _island(id: 2, faction: Faction.player, forces: 100, x: 0.9, y: 0.9),
+        _island(id: 3, faction: Faction.player, forces: 100, x: 0.1, y: 0.1),
+      ],
+    );
+
+    final decision = strategy.decide(state);
+
+    expect(decision, isNotNull);
+    expect(decision!.destinationIslandId, 3);
+  });
+
   test('applies exactly one CPU dispatch without changing its abilities', () {
     final strategy = CpuStrategy(random: Random(1), viewport: _viewport);
     final state = _playing(

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:conquest/game/cpu_strategy.dart';
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_loop.dart';
 import 'package:conquest/game/game_state.dart';
@@ -40,6 +41,7 @@ void main() {
       overrides: [
         gameLoopProvider.overrideWithValue(loop),
         randomProvider.overrideWithValue(Random(1)),
+        cpuStrategyProvider.overrideWithValue(CpuStrategy.noop()),
       ],
     );
   });


### PR DESCRIPTION
## 概要

標準難易度のCPU戦略を実装し、ゲーム内時間での判断、防衛優先、仕様どおりの攻撃先・出兵元選択、到着時の戦力予測を既存のゲームルールへ統合しました。

## 背景・目的

初期版の1人用CPU戦で、プレイヤーと同じ能力・ルールだけを使いながら、既知情報に基づいて再現可能な攻撃と防衛を継続できるようにします。

## 対応内容

- 注入可能な乱数で1.5〜3秒のCPU判断間隔を生成
- 1回の判断につき最大1部隊を通常の出兵ルールで作成
- 兵力増加、移動中の両軍部隊、同時到着を含む到着時予測を実装
- 防衛可能な自軍島への増援を最優先し、不可能な場合は通常攻撃へ移行
- 攻撃先・出兵元の優先順位と距離による同率解決を実装
- 既存部隊だけで占領予定の対象への重複出兵を回避
- countdown、一時停止、結果フェーズでCPU判断を停止
- 固定乱数、戦略単体、controller統合の回帰テストを追加

## 主な設計判断

- CPUの判断と予測は `CpuStrategy` に分離し、`GameController` はゲーム内時刻で判断予定を管理します。
- CPUの出兵には既存の `GameRules.createMovingForce` を使い、兵力・速度・上限の専用補正を持たせません。
- 到着時予測は現在判明している部隊だけを使い、新規候補部隊なしの反実仮想も比較して不要な重複出兵を除外します。

## 受け入れ条件との対応

- [x] CPUは1.5〜3秒の範囲で判断する
- [x] 1回の判断で作成する部隊は最大1件である
- [x] CPUの部隊と島にプレイヤーと異なる能力補正がない
- [x] 防衛増援で占領を防げる場合は攻撃より防衛を優先する
- [x] 防衛不可能な場合は通常攻撃へ進む
- [x] 攻撃先と出兵元の優先順位が仕様どおりである
- [x] 到着時予測に兵力増加と移動中部隊を含める
- [x] 予測不能な将来のプレイヤー操作は参照しない
- [x] 一時停止・カウントダウン・結果フェーズでは判断しない
- [x] 固定乱数と固定状態から同じ判断を再現できる
- [x] `fvm flutter analyze` と `fvm flutter test` が成功する

## 検証

- `fvm flutter test test/cpu_strategy_test.dart --suppress-analytics`: 成功（11件）
- `fvm flutter analyze --suppress-analytics`: 成功（No issues found）
- `fvm flutter test --suppress-analytics`: 成功（76件）
- `git diff --check origin/main...HEAD`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `5fb921ef3e825ee4777dc3297444a055c48e4958`）
- GitHub Codex review（1回のみ）: 未実施
- Required checks: pending

## 残存リスク

なし

Closes #11
