### PR TITLE
ゲーム設定・開始カウントダウン・盤面表示を実装

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -52,15 +52,10 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/lib/base.dart
+++ b/lib/base.dart
@@ -1,40 +1,139 @@
 import 'package:flutter/material.dart';
+
 import 'game/game_state.dart';
 
+/// The renderer for one island on the board.
+///
+/// Ownership is intentionally communicated through three independent cues:
+/// the color, the marker (P/C/N), and the outline shape.  The semantic label
+/// repeats the faction and numeric values so the board remains usable without
+/// relying on color or visual inspection.
 class Base extends StatelessWidget {
   const Base({required this.base, required this.onPressed, super.key});
 
   final IslandState base;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      //color: Colors.red,
+    final isNeutral = base.faction == Faction.neutral;
+    final label = _semanticLabel;
+
+    return Semantics(
+      container: true,
+      button: true,
+      enabled: onPressed != null,
+      label: label,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          backgroundColor: switch (base.control) {
-            BaseControl.ally => Colors.green,
-            BaseControl.enemy => Colors.red,
-            BaseControl.neutral => Colors.grey,
-          },
+          backgroundColor: _backgroundColor,
           foregroundColor: Colors.white,
-          shape: base.id == 0 || base.id == 1
-              ? null
-              : const CircleBorder(
-                  side: BorderSide(
-                    color: Colors.black,
-                    width: 1,
-                    style: BorderStyle.solid,
-                  ),
-                ),
+          padding: const EdgeInsets.all(3),
+          minimumSize: Size.zero,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          shape: _shape,
         ),
         onPressed: onPressed,
-        // controlが0か1の時のみscaleを表示
-        child: base.control != BaseControl.neutral
-            ? Text(base.scale.toString())
-            : const Text(''),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              _marker,
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w800,
+                height: 1,
+              ),
+            ),
+            if (isNeutral)
+              Text(
+                base.currentDurability.toString(),
+                key: ValueKey('island-${base.id}-value'),
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  height: 1.1,
+                ),
+              )
+            else ...[
+              Text(
+                base.currentForces.toString(),
+                key: ValueKey('island-${base.id}-current'),
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w900,
+                  height: 1.05,
+                ),
+              ),
+              Text(
+                '/${base.capacity}',
+                key: ValueKey('island-${base.id}-capacity'),
+                style: const TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  height: 1,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
+  }
+
+  Color get _backgroundColor {
+    return switch (base.faction) {
+      Faction.player => Colors.green.shade700,
+      Faction.cpu => Colors.red.shade700,
+      Faction.neutral => Colors.grey.shade700,
+    };
+  }
+
+  OutlinedBorder get _shape {
+    return switch (base.faction) {
+      Faction.player => const CircleBorder(
+        side: BorderSide(color: Colors.white, width: 3),
+      ),
+      Faction.cpu => const BeveledRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(9)),
+        side: BorderSide(color: Colors.white, width: 3),
+      ),
+      Faction.neutral => const CircleBorder(
+        side: BorderSide(color: Colors.black, width: 2),
+      ),
+    };
+  }
+
+  String get _marker {
+    return switch (base.faction) {
+      Faction.player => 'P',
+      Faction.cpu => 'C',
+      Faction.neutral => 'N',
+    };
+  }
+
+  String get _factionName {
+    return switch (base.faction) {
+      Faction.player => 'Player',
+      Faction.cpu => 'CPU',
+      Faction.neutral => 'Neutral',
+    };
+  }
+
+  String get _sizeName {
+    return switch (base.size) {
+      IslandSize.small => 'small island',
+      IslandSize.medium => 'medium island',
+      IslandSize.large => 'large island',
+      IslandSize.headquarters => 'headquarters',
+    };
+  }
+
+  String get _semanticLabel {
+    final value = base.faction == Faction.neutral
+        ? 'durability ${base.currentDurability}'
+        : 'forces ${base.currentForces} of ${base.capacity}';
+    return '$_factionName $_sizeName, $value';
   }
 }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -296,8 +296,10 @@ class GameController extends _$GameController {
     final nextState = _rules.tick(state, deltaMs: deltaMs);
     state = nextState;
     if (state.phase == GamePhase.playing) {
-      if (phaseBeforeTick == GamePhase.startCountdown ||
-          phaseBeforeTick == GamePhase.resumeCountdown) {
+      if (phaseBeforeTick == GamePhase.startCountdown) {
+        // The initial match has no pending CPU deadline yet.  A resume
+        // countdown intentionally skips this branch so its frozen, absolute
+        // deadline remains unchanged across the pause interval.
         _scheduleNextCpuDecision();
       }
       _runCpuDecisionIfDue();

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -79,9 +79,15 @@ class GameController extends _$GameController {
     if (previousState != null &&
         previousState.phase != GamePhase.configuration) {
       _cachedViewport = viewport;
-      if (previousState.phase == GamePhase.playing && !_gameLoop.isRunning) {
+      final shouldResumeLoop =
+          previousState.phase == GamePhase.startCountdown ||
+          previousState.phase == GamePhase.resumeCountdown ||
+          previousState.phase == GamePhase.playing;
+      if (shouldResumeLoop && !_gameLoop.isRunning) {
         // A dependency rebuild runs the disposal callback before build. Keep
-        // an in-progress match alive by resuming its loop after rebuilding.
+        // an in-progress match or countdown alive by resuming its loop after
+        // rebuilding. Reset the wall-clock baseline so time spent rebuilding
+        // cannot advance the game past the countdown boundary.
         _lastTickMs = _clock.nowMs();
         _gameLoop.start(_tick);
       }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -91,10 +91,12 @@ class GameController extends _$GameController {
     return _initialStateFor(configuration: configuration, viewport: viewport);
   }
 
-  /// Starts a match and the production/manual loop.  The first screen in
-  /// PR #3 started immediately on tap; the countdown phase remains available
-  /// through [GameRules.startCountdown] while this compatibility entry point
-  /// keeps that startup behavior unchanged.
+  /// Starts a match and the production/manual loop.
+  ///
+  /// The generated map remains visible while [GamePhase.startCountdown] is
+  /// active.  The rules engine does not advance game time, move forces, grow
+  /// islands, or run CPU decisions during that phase; the first playing tick
+  /// after the countdown is the shared start boundary for every subsystem.
   void startGame() {
     if (_disposed || state.phase == GamePhase.playing) {
       return;
@@ -109,16 +111,7 @@ class GameController extends _$GameController {
       return;
     }
 
-    final wasPaused = state.phase == GamePhase.paused;
-    // Preserve the existing tap-to-play behavior.  Consumers that need a
-    // visible countdown can apply GameRules.tick to the same state instead.
-    state = nextState.copyWith(
-      phase: GamePhase.playing,
-      countdownRemainingMs: 0,
-    );
-    if (!wasPaused || _nextCpuDecisionAtMs == null) {
-      _scheduleNextCpuDecision();
-    }
+    state = nextState;
     _lastTickMs = _clock.nowMs();
     _gameLoop.start(_tick);
   }
@@ -140,17 +133,10 @@ class GameController extends _$GameController {
     if (nextState == state) {
       return;
     }
-    // See startGame: preserve the established immediate-resume UI behavior.
-    state = nextState.copyWith(
-      phase: GamePhase.playing,
-      countdownRemainingMs: 0,
-    );
+    state = nextState;
     // Game time is frozen while paused, so preserve the pending judgment's
     // absolute game-time deadline across resume.  A null deadline only occurs
     // after a rebuilt controller and needs a fresh injected interval.
-    if (_nextCpuDecisionAtMs == null) {
-      _scheduleNextCpuDecision();
-    }
     _lastTickMs = _clock.nowMs();
     _gameLoop.start(_tick);
   }
@@ -300,9 +286,14 @@ class GameController extends _$GameController {
         ? 0
         : now - previous;
     final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
+    final phaseBeforeTick = state.phase;
     final nextState = _rules.tick(state, deltaMs: deltaMs);
     state = nextState;
     if (state.phase == GamePhase.playing) {
+      if (phaseBeforeTick == GamePhase.startCountdown ||
+          phaseBeforeTick == GamePhase.resumeCountdown) {
+        _scheduleNextCpuDecision();
+      }
       _runCpuDecisionIfDue();
     }
     if (nextState.phase == GamePhase.result) {

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -122,11 +122,14 @@ final class GameRules {
   static const mapMinCoordinate = -1.0;
   static const mapMaxCoordinate = 1.0;
 
-  /// These dimensions are shared with [Home]'s `SizedBox` widgets.  Neutral
-  /// island variants currently use the same 50px square; the enum is retained
-  /// in the API so a future renderer can give each variant its own size.
+  /// These dimensions are shared with [Home]'s `SizedBox` widgets.  Distinct
+  /// sizes make the small, medium, large, and headquarters roles visible on
+  /// the board while keeping the small-island footprint compatible with the
+  /// original map envelope.
   static const headquartersWidgetSize = 100.0;
   static const neutralWidgetSize = 50.0;
+  static const mediumIslandWidgetSize = 64.0;
+  static const largeIslandWidgetSize = 80.0;
   static const movingForceWidgetSize = 30.0;
 
   /// A layout-independent fallback for state creation before Flutter layout
@@ -142,9 +145,12 @@ final class GameRules {
   static const defaultPairPlacementAttempts = 128;
 
   static double islandWidgetSize(IslandSize size) {
-    return size == IslandSize.headquarters
-        ? headquartersWidgetSize
-        : neutralWidgetSize;
+    return switch (size) {
+      IslandSize.headquarters => headquartersWidgetSize,
+      IslandSize.small => neutralWidgetSize,
+      IslandSize.medium => mediumIslandWidgetSize,
+      IslandSize.large => largeIslandWidgetSize,
+    };
   }
 
   GameState initialState({

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -41,60 +41,181 @@ class _GameSurface extends ConsumerWidget {
     final state = ref.watch(gameControllerProvider);
     final controller = ref.read(gameControllerProvider.notifier);
 
-    return GestureDetector(
-      onTap: () {
-        if (state.phase == GamePhase.ready) {
-          controller.startGame();
-        }
-      },
-      child: Stack(
-        children: [
-          // * 背景
-          Container(height: double.infinity, color: Colors.blue),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        const ColoredBox(color: Colors.blue),
+        Semantics(
+          container: true,
+          label: 'Island map, ${state.configuration.totalIslandCount} islands',
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              for (final island in state.islands)
+                Align(
+                  key: ValueKey('island-${island.id}'),
+                  alignment: Alignment(island.x, island.y),
+                  child: SizedBox.square(
+                    dimension: GameRules.islandWidgetSize(island.size),
+                    child: Base(
+                      key: ValueKey('island-button-${island.id}'),
+                      base: island,
+                      onPressed: state.phase == GamePhase.playing
+                          ? () => controller.tapBase(island.id)
+                          : null,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        if (state.phase == GamePhase.configuration && state.islands.isNotEmpty)
+          _ConfigurationPanel(state: state, onStart: controller.startGame),
+        _CountdownBanner(state: state),
+      ],
+    );
+  }
+}
 
-          // * 拠点(自動生成)
-          for (final base in state.bases) ...[
-            Align(
-              alignment: Alignment(base.x, base.y),
-              child: SizedBox(
-                height: GameRules.islandWidgetSize(base.size),
-                width: GameRules.islandWidgetSize(base.size),
-                child: Base(
-                  base: base,
-                  onPressed: () => controller.tapBase(base.id),
+class _ConfigurationPanel extends StatelessWidget {
+  const _ConfigurationPanel({required this.state, required this.onStart});
+
+  final GameState state;
+  final VoidCallback onStart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Material(
+          color: Colors.black.withValues(alpha: 0.78),
+          borderRadius: BorderRadius.circular(14),
+          elevation: 4,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Semantics(
+                  header: true,
+                  child: Text(
+                    'Choose total islands',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 7),
+                Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [
+                    for (final count in GameConfiguration.allowedIslandCounts)
+                      Semantics(
+                        button: true,
+                        selected: state.configuration.totalIslandCount == count,
+                        label: '$count islands',
+                        child: ChoiceChip(
+                          key: ValueKey('island-count-$count'),
+                          label: Text('$count'),
+                          selected:
+                              state.configuration.totalIslandCount == count,
+                          onSelected: (_) => _selectCount(context, count),
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
+                          tooltip: '$count islands',
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Semantics(
+                  button: true,
+                  label:
+                      'Start game with ${state.configuration.totalIslandCount} islands',
+                  child: ElevatedButton(
+                    key: const ValueKey('start-game'),
+                    onPressed: onStart,
+                    child: const Text('START GAME'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _selectCount(BuildContext context, int count) {
+    final container = ProviderScope.containerOf(context);
+    container.read(gameControllerProvider.notifier).selectIslandCount(count);
+  }
+}
+
+class _CountdownBanner extends StatelessWidget {
+  const _CountdownBanner({required this.state});
+
+  final GameState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = _countdownText;
+    if (text == null) {
+      return const SizedBox.shrink();
+    }
+
+    return IgnorePointer(
+      child: Center(
+        child: Semantics(
+          liveRegion: true,
+          label: 'Game start $text',
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.62),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(color: Colors.white, width: 2),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 18),
+              child: Text(
+                text,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 42,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 2,
                 ),
               ),
             ),
-          ],
-
-          // * Tank
-          state.movement != null
-              ? Align(
-                  alignment: Alignment(state.movement!.x, state.movement!.y),
-                  child: Container(
-                    key: const ValueKey('tank'),
-                    color: Colors.red,
-                    height: 30,
-                    width: 30,
-                    child: Center(
-                      child: Text(state.movement!.scale.toString()),
-                    ),
-                  ),
-                )
-              : const SizedBox(),
-
-          // * Ready画面
-          state.phase == GamePhase.ready
-              ? const Align(
-                  alignment: Alignment(0, -0.2),
-                  child: Text(
-                    'T A P  T O  P L A Y',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                )
-              : const SizedBox(),
-        ],
+          ),
+        ),
       ),
     );
+  }
+
+  String? get _countdownText {
+    if (state.phase == GamePhase.startCountdown ||
+        state.phase == GamePhase.resumeCountdown) {
+      if (state.countdownRemainingMs > 2000) {
+        return '3';
+      }
+      if (state.countdownRemainingMs > 1000) {
+        return '2';
+      }
+      if (state.countdownRemainingMs > 0) {
+        return '1';
+      }
+      return null;
+    }
+    if (state.phase == GamePhase.playing && state.elapsedMs == 0) {
+      return 'START';
+    }
+    return null;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'home.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations(const [
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/test/cpu_controller_integration_test.dart
+++ b/test/cpu_controller_integration_test.dart
@@ -106,4 +106,40 @@ void main() {
     loop.tick();
     expect(container.read(gameControllerProvider), paused);
   });
+
+  test('retains a pending CPU deadline across the resume countdown', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    completeStartCountdown(loop);
+
+    for (var index = 0; index < 29; index++) {
+      loop.tick();
+    }
+    expect(container.read(gameControllerProvider).elapsedMs, 1450);
+    expect(
+      container
+          .read(gameControllerProvider)
+          .movingForces
+          .where((force) => force.faction == Faction.cpu),
+      isEmpty,
+    );
+
+    controller.pauseGame();
+    controller.resumeGame();
+    expect(
+      container.read(gameControllerProvider).phase,
+      GamePhase.resumeCountdown,
+    );
+    completeStartCountdown(loop);
+    expect(container.read(gameControllerProvider).elapsedMs, 1450);
+
+    loop.tick();
+    expect(
+      container
+          .read(gameControllerProvider)
+          .movingForces
+          .where((force) => force.faction == Faction.cpu),
+      hasLength(1),
+    );
+  });
 }

--- a/test/cpu_controller_integration_test.dart
+++ b/test/cpu_controller_integration_test.dart
@@ -19,6 +19,12 @@ final class ZeroRandom implements Random {
   int nextInt(int max) => 0;
 }
 
+void completeStartCountdown(ManualGameLoop loop) {
+  for (var index = 0; index < 60; index++) {
+    loop.tick();
+  }
+}
+
 void main() {
   late ManualGameLoop loop;
   late ProviderContainer container;
@@ -44,6 +50,7 @@ void main() {
   test('dispatches at most one CPU troop per due judgment', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
 
     for (var index = 0; index < 29; index++) {
       loop.tick();

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -31,6 +31,12 @@ class ManualGameLoop implements GameLoop {
   void tick() => _onTick?.call();
 }
 
+void completeStartCountdown(ManualGameLoop loop) {
+  for (var index = 0; index < 60; index++) {
+    loop.tick();
+  }
+}
+
 void main() {
   late ManualGameLoop loop;
   late ProviderContainer container;
@@ -101,13 +107,54 @@ void main() {
     controller.startGame();
     controller.startGame();
 
-    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
+    expect(
+      container.read(gameControllerProvider).phase,
+      GamePhase.startCountdown,
+    );
     expect(loop.startCount, 1);
+  });
+
+  test('holds the generated map during the start countdown', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    final initial = container.read(gameControllerProvider);
+
+    controller.startGame();
+
+    expect(
+      container.read(gameControllerProvider).phase,
+      GamePhase.startCountdown,
+    );
+    expect(container.read(gameControllerProvider).countdownRemainingMs, 3000);
+    expect(container.read(gameControllerProvider).elapsedMs, 0);
+
+    controller.tapBase(0);
+    expect(container.read(gameControllerProvider).selectedIslandId, isNull);
+    expect(container.read(gameControllerProvider).movingForces, isEmpty);
+
+    for (var index = 0; index < 59; index++) {
+      loop.tick();
+    }
+    final beforeStart = container.read(gameControllerProvider);
+    expect(beforeStart.phase, GamePhase.startCountdown);
+    expect(beforeStart.countdownRemainingMs, 50);
+    expect(beforeStart.elapsedMs, 0);
+    expect(beforeStart.islands, initial.islands);
+
+    loop.tick();
+    final started = container.read(gameControllerProvider);
+    expect(started.phase, GamePhase.playing);
+    expect(started.countdownRemainingMs, 0);
+    expect(started.elapsedMs, 0);
+    expect(loop.isRunning, isTrue);
+
+    loop.tick();
+    expect(container.read(gameControllerProvider).elapsedMs, 50);
   });
 
   test('selects a source and creates movement on the next tap', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
 
     controller.tapBase(0);
     expect(container.read(gameControllerProvider).selectedBaseId, 0);
@@ -129,6 +176,7 @@ void main() {
     () {
       final controller = container.read(gameControllerProvider.notifier);
       controller.startGame();
+      completeStartCountdown(loop);
 
       controller.tapBase(2);
       expect(container.read(gameControllerProvider).selectedBaseId, isNull);
@@ -146,6 +194,7 @@ void main() {
     () {
       final controller = container.read(gameControllerProvider.notifier);
       controller.startGame();
+      completeStartCountdown(loop);
       controller.tapBase(0);
 
       final selected = container.read(gameControllerProvider);
@@ -180,6 +229,7 @@ void main() {
     () {
       final controller = container.read(gameControllerProvider.notifier);
       controller.startGame();
+      completeStartCountdown(loop);
       final playing = container.read(gameControllerProvider);
 
       for (final force in [0, 1, 2, 5, 200]) {
@@ -209,6 +259,7 @@ void main() {
   test('preserves a selected source across ticks before destination tap', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
     controller.tapBase(0);
 
     loop.tick();
@@ -226,6 +277,7 @@ void main() {
   test('ticks movement and resolves it at the target', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
     controller.tapBase(0);
     controller.tapBase(1);
 
@@ -243,6 +295,7 @@ void main() {
   test('stops the game loop when arrival resolution finalizes a result', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
     controller.state = GameState(
       phase: GamePhase.playing,
       elapsedMs: 0,
@@ -289,6 +342,7 @@ void main() {
     () {
       final controller = container.read(gameControllerProvider.notifier);
       controller.startGame();
+      completeStartCountdown(loop);
 
       for (var i = 0; i < 20; i++) {
         loop.tick();
@@ -306,6 +360,7 @@ void main() {
   test('appends consecutive dispatches from one source', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
     controller.tapBase(0);
     controller.tapBase(1);
     final first = container.read(gameControllerProvider).movingForces.single;
@@ -328,6 +383,7 @@ void main() {
   test('keeps troops from different sources independent', () {
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
+    completeStartCountdown(loop);
 
     final initial = container.read(gameControllerProvider);
     controller.state = initial.copyWith(

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -1753,7 +1753,9 @@ void main() {
 
     final controller = container.read(gameControllerProvider.notifier);
     controller.startGame();
-    clock.value = 125;
+    clock.value = 3000;
+    loop.tick();
+    clock.value = 3125;
     loop.tick();
 
     expect(container.read(gameControllerProvider).elapsedMs, 125);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -376,6 +376,56 @@ void main() {
     },
   );
 
+  testWidgets('continues the start countdown after a viewport change', (
+    tester,
+  ) async {
+    final loop = ManualWidgetGameLoop();
+    await tester.binding.setSurfaceSize(const Size(320, 500));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('start-game')));
+    await tester.pump();
+    final beforeResize = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    );
+    expect(
+      beforeResize.read(gameControllerProvider).phase,
+      GamePhase.startCountdown,
+    );
+    expect(
+      beforeResize.read(gameControllerProvider).countdownRemainingMs,
+      3000,
+    );
+    expect(loop.isRunning, isTrue);
+
+    await tester.binding.setSurfaceSize(const Size(321, 500));
+    await tester.pump();
+
+    final afterResize = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    );
+    expect(
+      afterResize.read(gameControllerProvider).phase,
+      GamePhase.startCountdown,
+    );
+    expect(afterResize.read(gameControllerProvider).countdownRemainingMs, 3000);
+    expect(loop.isRunning, isTrue);
+
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    expect(afterResize.read(gameControllerProvider).phase, GamePhase.playing);
+  });
+
   testWidgets('preserves an in-progress game after the viewport changes', (
     tester,
   ) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -26,15 +26,44 @@ class ManualWidgetGameLoop implements GameLoop {
 }
 
 void main() {
-  testWidgets('shows the ready screen and ten bases', (tester) async {
-    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+  testWidgets('offers every island-count preset with ten selected initially', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [randomProvider.overrideWithValue(Random(1))],
+        child: const MyApp(),
+      ),
+    );
 
-    expect(find.byType(Scaffold), findsOneWidget);
-    expect(find.text('T A P  T O  P L A Y'), findsOneWidget);
-    expect(find.byType(ElevatedButton), findsNWidgets(10));
+    for (final count in GameConfiguration.allowedIslandCounts) {
+      expect(find.byKey(ValueKey('island-count-$count')), findsOneWidget);
+    }
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-count-10'))),
+    );
+    expect(
+      container.read(gameControllerProvider).configuration.totalIslandCount,
+      10,
+    );
+    expect(
+      tester
+          .widget<ChoiceChip>(find.byKey(const ValueKey('island-count-10')))
+          .selected,
+      isTrue,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('island-count-6')));
+    await tester.pump();
+
+    expect(
+      container.read(gameControllerProvider).configuration.totalIslandCount,
+      6,
+    );
+    expect(container.read(gameControllerProvider).islands, hasLength(6));
   });
 
-  testWidgets('renders and clears a moving tank through Riverpod state', (
+  testWidgets('shows the map before countdown and starts exactly at zero', (
     tester,
   ) async {
     final loop = ManualWidgetGameLoop();
@@ -48,20 +77,138 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('T A P  T O  P L A Y'));
-    await tester.pump();
-    await tester.tap(find.byType(ElevatedButton).at(0));
-    await tester.tap(find.byType(ElevatedButton).at(1));
-    await tester.pump();
+    expect(find.byKey(const ValueKey('island-0')), findsOneWidget);
+    expect(find.text('3'), findsNothing);
 
-    expect(find.byKey(const ValueKey('tank')), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('start-game')));
+    await tester.pump();
+    expect(find.text('3'), findsOneWidget);
+    expect(find.byKey(const ValueKey('island-0')), findsOneWidget);
 
-    for (var i = 0; i < 100; i++) {
+    for (var index = 0; index < 59; index++) {
       loop.tick();
     }
     await tester.pump();
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('2'), findsNothing);
 
-    expect(find.byKey(const ValueKey('tank')), findsNothing);
+    loop.tick();
+    await tester.pump();
+    expect(find.text('START'), findsOneWidget);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    );
+    final state = container.read(gameControllerProvider);
+    expect(state.phase, GamePhase.playing);
+    expect(state.elapsedMs, 0);
+  });
+
+  testWidgets('shows the generated map and configuration controls', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+
+    expect(find.byType(Scaffold), findsOneWidget);
+    expect(find.byKey(const ValueKey('start-game')), findsOneWidget);
+    expect(find.byKey(const ValueKey('island-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('island-9')), findsOneWidget);
+  });
+
+  testWidgets('exposes faction, size, and numeric values semantically', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [randomProvider.overrideWithValue(Random(1))],
+        child: const MyApp(),
+      ),
+    );
+
+    expect(
+      tester.getSemantics(find.byKey(const ValueKey('island-button-0'))).label,
+      contains('Player headquarters, forces 100 of 200'),
+    );
+    expect(
+      tester.getSemantics(find.byKey(const ValueKey('island-button-1'))).label,
+      contains('CPU headquarters, forces 100 of 200'),
+    );
+    expect(
+      tester.getSemantics(find.byKey(const ValueKey('island-button-2'))).label,
+      contains('Neutral small island, durability 10'),
+    );
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('island-button-2'))).width,
+      50,
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('island-button-6'))).width,
+      64,
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('island-button-8'))).width,
+      80,
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('island-button-0'))).width,
+      100,
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('keeps every island-count preset physically operable', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [randomProvider.overrideWithValue(Random(1))],
+        child: const MyApp(),
+      ),
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    );
+    final controller = container.read(gameControllerProvider.notifier);
+    for (final count in GameConfiguration.allowedIslandCounts) {
+      controller.selectIslandCount(count);
+      await tester.pump();
+      final state = container.read(gameControllerProvider);
+      expect(state.islands, hasLength(count));
+
+      final rectangles = [
+        for (final island in state.islands)
+          (
+            topLeft: tester.getTopLeft(
+              find.byKey(ValueKey('island-button-${island.id}')),
+            ),
+            size: tester.getSize(
+              find.byKey(ValueKey('island-button-${island.id}')),
+            ),
+          ),
+      ];
+      for (var first = 0; first < rectangles.length; first++) {
+        final firstRect = Rect.fromLTWH(
+          rectangles[first].topLeft.dx,
+          rectangles[first].topLeft.dy,
+          rectangles[first].size.width,
+          rectangles[first].size.height,
+        );
+        for (var second = first + 1; second < rectangles.length; second++) {
+          final secondRect = Rect.fromLTWH(
+            rectangles[second].topLeft.dx,
+            rectangles[second].topLeft.dy,
+            rectangles[second].size.width,
+            rectangles[second].size.height,
+          );
+          expect(firstRect.overlaps(secondRect), isFalse);
+        }
+      }
+    }
   });
 
   testWidgets('keeps headquarters inside the SafeArea insets', (tester) async {
@@ -82,10 +229,10 @@ void main() {
       ),
     );
 
-    final buttons = find.byType(ElevatedButton);
-    expect(buttons, findsNWidgets(10));
-    expect(tester.getTopLeft(buttons.at(1)).dy, closeTo(24, 1e-6));
-    expect(tester.getBottomRight(buttons.at(0)).dy, closeTo(484, 1e-6));
+    final cpu = find.byKey(const ValueKey('island-button-1'));
+    final player = find.byKey(const ValueKey('island-button-0'));
+    expect(tester.getTopLeft(cpu).dy, closeTo(24, 1e-6));
+    expect(tester.getBottomRight(player).dy, closeTo(484, 1e-6));
   });
 
   testWidgets('generates using the actual sub-320 layout constraints', (
@@ -191,6 +338,9 @@ void main() {
       controller.selectIslandCount(6);
       await tester.pump();
       controller.startGame();
+      for (var index = 0; index < 60; index++) {
+        loop.tick();
+      }
       controller.tapBase(0);
       controller.tapBase(1);
       loop.tick();
@@ -242,10 +392,14 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('T A P  T O  P L A Y'));
+    await tester.tap(find.byKey(const ValueKey('start-game')));
     await tester.pump();
-    await tester.tap(find.byType(ElevatedButton).at(0));
-    await tester.tap(find.byType(ElevatedButton).at(1));
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('island-button-0')));
+    await tester.tap(find.byKey(const ValueKey('island-button-1')));
     loop.tick();
     await tester.pump();
 


### PR DESCRIPTION
## 概要

1人用CPU戦の開始前設定、3秒カウントダウン、全島の状態を常時確認できる基本盤面UIを実装します。

## 背景・目的

初期版の試合開始条件と盤面表示をIssue #12の仕様に揃え、選択した島数のマップを確認してからゲーム処理を同時開始できるようにします。

## 対応内容

- 合計島数6・8・10・12の設定UIと初期値10島を追加
- 選択値から点対称マップを生成し、生成後に3、2、1、STARTを表示
- カウントダウン終了前は操作・CPU判断・兵力増加・移動を停止し、終了時にゲームループを開始
- Safe Area内に縦向き盤面を配置し、HQ・島サイズ・陣営・現在値・上限値・耐久力を表示
- 色に加えて陣営マーク、輪郭、Semanticsで所属と数値を識別可能に変更
- 全プリセットの非重複配置、カウントダウン中resize、縦向き構成の回帰テストを追加

## 主な設計判断

- #7の既存マップ生成とGameControllerのphaseを再利用し、UI固有の別状態を増やさない構成とした
- viewport再構築時もactive phaseのloopを再開し、カウントダウン停止を防ぐ
- Issue対象外の選択フィードバック、移動部隊描画、CPU戦略、一時停止・結果・再戦UIは追加しない

## 受け入れ条件との対応

- [x] 設定画面で4種類の合計島数を選択でき、初期選択を10島に設定
- [x] 選択した島数で#7のマップを生成
- [x] マップ表示後に3秒カウントダウンを行い、終了前のゲーム進行を停止
- [x] スマートフォン縦向きに固定
- [x] 本陣、島サイズ、陣営を仕様どおりに表示し、色以外でも識別可能
- [x] 全島の兵力または耐久力と、占領済み島の現在値・上限値を区別して表示
- [x] 6・8・10・12島すべてで物理的な重なりがないことをWidgetテストで確認
- [x] analyzeとfull testに成功

## 検証

- `fvm dart format --output=none --set-exit-if-changed <changed Dart files>`: 成功
- `git diff --check origin/main...HEAD`: 成功
- `fvm flutter analyze`: 成功（No issues found）
- `fvm flutter test`: 成功（82 tests passed）
- `plutil -lint ios/Runner/Info.plist`: 成功
- `xmllint --noout android/app/src/main/AndroidManifest.xml`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `5dcfce64947556508825f468a841288c4438c14f`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `102ebbd3eef8089683aee321a7d01ba147e2dc19`、fix HEAD: `5dcfce64947556508825f468a841288c4438c14f`）
- Required checks: 対象なし

## 残存リスク

実機固有のSafe AreaとOS回転挙動は未確認です。ネイティブ構成検証とWidgetテストで代替確認しています。

Closes #12