### PR TITLE
[Game Rules] 一時停止・ライフサイクル・結果画面を実装する

### DIFF
--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -197,6 +197,16 @@ class GameController extends _$GameController {
       configuration: state.configuration,
       viewport: ref.read(mapViewportProvider),
     );
+    if (initial.islands.length != state.configuration.totalIslandCount) {
+      // Map generation can fail closed for a viewport that cannot fit the
+      // fixed headquarters. Never start a zero-island replay, which would
+      // otherwise resolve immediately as a draw.
+      _gameLoop.stop();
+      _nextCpuDecisionAtMs = null;
+      _lastTickMs = null;
+      state = initial;
+      return;
+    }
     final countdown = _rules.startCountdown(initial);
     state = countdown;
     _nextCpuDecisionAtMs = null;

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -123,7 +123,10 @@ class GameController extends _$GameController {
   }
 
   void pauseGame() {
-    if (_disposed || state.phase != GamePhase.playing) {
+    if (_disposed ||
+        (state.phase != GamePhase.playing &&
+            state.phase != GamePhase.startCountdown &&
+            state.phase != GamePhase.resumeCountdown)) {
       return;
     }
     state = _rules.pause(state);
@@ -158,7 +161,51 @@ class GameController extends _$GameController {
     state = nextState;
     _gameLoop.stop();
     _lastTickMs = null;
+    _nextCpuDecisionAtMs = null;
   }
+
+  /// Leaves the current match and shows the island-count configuration again.
+  ///
+  /// A match is intentionally not persisted.  Returning to settings creates
+  /// a fresh map, clears all transient match state, and leaves the loop
+  /// stopped until the player starts another match.
+  void returnToConfiguration() {
+    if (_disposed ||
+        (state.phase != GamePhase.paused && state.phase != GamePhase.result)) {
+      return;
+    }
+
+    _gameLoop.stop();
+    _lastTickMs = null;
+    _nextCpuDecisionAtMs = null;
+    state = _newInitialStateFor(
+      configuration: state.configuration,
+      viewport: ref.read(mapViewportProvider),
+    );
+  }
+
+  /// Alias matching the action's user-facing wording.
+  void returnToSettings() => returnToConfiguration();
+
+  /// Starts a new match with the same island count and a newly generated map.
+  void replayGame() {
+    if (_disposed || state.phase != GamePhase.result) {
+      return;
+    }
+
+    final initial = _newInitialStateFor(
+      configuration: state.configuration,
+      viewport: ref.read(mapViewportProvider),
+    );
+    final countdown = _rules.startCountdown(initial);
+    state = countdown;
+    _nextCpuDecisionAtMs = null;
+    _lastTickMs = _clock.nowMs();
+    _gameLoop.start(_tick);
+  }
+
+  /// Compatibility alias for callers that name the replay action restart.
+  void restartGame() => replayGame();
 
   /// Changes the selected island count before a match starts and regenerates
   /// only the typed initial state.  Concrete map placement remains a later
@@ -189,6 +236,27 @@ class GameController extends _$GameController {
       return _cachedInitialState!;
     }
 
+    final nextState =
+        _rules.tryInitialState(
+          configuration: configuration,
+          random: _random,
+          viewport: viewport,
+        ) ??
+        GameState(
+          configuration: configuration,
+          phase: GamePhase.configuration,
+          elapsedMs: 0,
+        );
+    _cachedConfiguration = configuration;
+    _cachedViewport = viewport;
+    _cachedInitialState = nextState;
+    return nextState;
+  }
+
+  GameState _newInitialStateFor({
+    required GameConfiguration configuration,
+    required IslandMapViewport viewport,
+  }) {
     final nextState =
         _rules.tryInitialState(
           configuration: configuration,

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -339,11 +339,13 @@ final class GameRules {
     }
     return switch (from) {
       GamePhase.configuration => to == GamePhase.startCountdown,
-      GamePhase.startCountdown => to == GamePhase.playing,
+      GamePhase.startCountdown =>
+        to == GamePhase.playing || to == GamePhase.paused,
       GamePhase.playing => to == GamePhase.paused || to == GamePhase.result,
       GamePhase.paused =>
         to == GamePhase.resumeCountdown || to == GamePhase.configuration,
-      GamePhase.resumeCountdown => to == GamePhase.playing,
+      GamePhase.resumeCountdown =>
+        to == GamePhase.playing || to == GamePhase.paused,
       GamePhase.result => to == GamePhase.configuration,
     };
   }
@@ -400,7 +402,12 @@ final class GameRules {
   }
 
   GameState pause(GameState state) {
-    return transitionTo(state, GamePhase.paused);
+    if (state.phase != GamePhase.playing &&
+        state.phase != GamePhase.startCountdown &&
+        state.phase != GamePhase.resumeCountdown) {
+      return state;
+    }
+    return state.transitionToPhase(GamePhase.paused);
   }
 
   GameState finish(GameState state, GameResult result) {

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -33,11 +33,39 @@ class Home extends StatelessWidget {
   }
 }
 
-class _GameSurface extends ConsumerWidget {
+class _GameSurface extends ConsumerStatefulWidget {
   const _GameSurface();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_GameSurface> createState() => _GameSurfaceState();
+}
+
+class _GameSurfaceState extends ConsumerState<_GameSurface>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState lifecycleState) {
+    if (lifecycleState == AppLifecycleState.inactive ||
+        lifecycleState == AppLifecycleState.paused ||
+        lifecycleState == AppLifecycleState.hidden ||
+        lifecycleState == AppLifecycleState.detached) {
+      ref.read(gameControllerProvider.notifier).pauseGame();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(gameControllerProvider);
     final controller = ref.read(gameControllerProvider.notifier);
 
@@ -71,8 +99,194 @@ class _GameSurface extends ConsumerWidget {
         ),
         if (state.phase == GamePhase.configuration && state.islands.isNotEmpty)
           _ConfigurationPanel(state: state, onStart: controller.startGame),
+        if (state.phase == GamePhase.playing)
+          _PauseButton(onPressed: controller.pauseGame),
+        if (state.phase == GamePhase.paused)
+          _PauseMenu(
+            onResume: controller.resumeGame,
+            onQuit: () => _confirmQuit(context, controller),
+          ),
+        if (state.phase == GamePhase.result)
+          _ResultPanel(
+            result: state.result!,
+            onReplay: controller.replayGame,
+            onSettings: controller.returnToConfiguration,
+          ),
         _CountdownBanner(state: state),
       ],
+    );
+  }
+
+  Future<void> _confirmQuit(
+    BuildContext context,
+    GameController controller,
+  ) async {
+    final shouldQuit = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Quit match?'),
+          content: const Text('Your current match will not be saved.'),
+          actions: [
+            TextButton(
+              key: const ValueKey('cancel-quit'),
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('CANCEL'),
+            ),
+            TextButton(
+              key: const ValueKey('confirm-quit'),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('QUIT'),
+            ),
+          ],
+        );
+      },
+    );
+    if (shouldQuit == true && mounted) {
+      controller.returnToConfiguration();
+    }
+  }
+}
+
+class _PauseButton extends StatelessWidget {
+  const _PauseButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Semantics(
+          button: true,
+          label: 'Pause game',
+          child: ElevatedButton(
+            key: const ValueKey('pause-game'),
+            onPressed: onPressed,
+            child: const Text('PAUSE'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PauseMenu extends StatelessWidget {
+  const _PauseMenu({required this.onResume, required this.onQuit});
+
+  final VoidCallback onResume;
+  final VoidCallback onQuit;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Colors.black.withValues(alpha: 0.62),
+      child: Center(
+        child: Material(
+          color: Colors.black.withValues(alpha: 0.86),
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Game Paused',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 26,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  key: const ValueKey('resume-game'),
+                  onPressed: onResume,
+                  child: const Text('RESUME'),
+                ),
+                const SizedBox(height: 8),
+                OutlinedButton(
+                  key: const ValueKey('quit-game'),
+                  onPressed: onQuit,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    side: const BorderSide(color: Colors.white),
+                  ),
+                  child: const Text('QUIT MATCH'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultPanel extends StatelessWidget {
+  const _ResultPanel({
+    required this.result,
+    required this.onReplay,
+    required this.onSettings,
+  });
+
+  final GameResult result;
+  final VoidCallback onReplay;
+  final VoidCallback onSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = switch (result.type) {
+      GameResultType.victory => 'Victory',
+      GameResultType.defeat => 'Defeat',
+      GameResultType.draw => 'Draw',
+    };
+    return ColoredBox(
+      color: Colors.black.withValues(alpha: 0.62),
+      child: Center(
+        child: Material(
+          color: Colors.black.withValues(alpha: 0.86),
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Semantics(
+                  header: true,
+                  liveRegion: true,
+                  child: Text(
+                    title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 30,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  key: const ValueKey('replay-game'),
+                  onPressed: onReplay,
+                  child: const Text('PLAY AGAIN'),
+                ),
+                const SizedBox(height: 8),
+                OutlinedButton(
+                  key: const ValueKey('return-settings'),
+                  onPressed: onSettings,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    side: const BorderSide(color: Colors.white),
+                  ),
+                  child: const Text('RETURN TO SETTINGS'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:conquest/game/cpu_strategy.dart';
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_loop.dart';
+import 'package:conquest/game/game_rules.dart';
 import 'package:conquest/game/game_state.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -504,4 +505,41 @@ void main() {
     );
     expect(container.read(gameControllerProvider).countdownRemainingMs, 3000);
   });
+
+  test(
+    'fails closed when replay map generation cannot produce a valid map',
+    () {
+      final failedLoop = ManualGameLoop();
+      final failedContainer = ProviderContainer(
+        overrides: [
+          gameLoopProvider.overrideWithValue(failedLoop),
+          mapViewportProvider.overrideWithValue(
+            const IslandMapViewport(width: 180, height: 180),
+          ),
+          randomProvider.overrideWithValue(Random(1)),
+          cpuStrategyProvider.overrideWithValue(CpuStrategy.noop()),
+        ],
+      );
+      addTearDown(failedContainer.dispose);
+
+      final controller = failedContainer.read(gameControllerProvider.notifier);
+      controller.state = GameState(
+        configuration: GameConfiguration(totalIslandCount: 6),
+        phase: GamePhase.result,
+        elapsedMs: 120,
+        result: const GameResult.victory(elapsedMs: 120),
+      );
+
+      controller.replayGame();
+
+      final state = failedContainer.read(gameControllerProvider);
+      expect(state.phase, GamePhase.configuration);
+      expect(state.configuration.totalIslandCount, 6);
+      expect(state.islands, isEmpty);
+      expect(state.movingForces, isEmpty);
+      expect(state.result, isNull);
+      expect(state.elapsedMs, 0);
+      expect(failedLoop.isRunning, isFalse);
+    },
+  );
 }

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -432,4 +432,76 @@ void main() {
     expect(loop.stopCount, 1);
     expect(loop.isRunning, isFalse);
   });
+
+  test('returns a paused match to settings without retaining match state', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    completeStartCountdown(loop);
+    controller.tapBase(0);
+    controller.tapBase(1);
+    loop.tick();
+
+    final beforeQuit = container.read(gameControllerProvider);
+    expect(beforeQuit.phase, GamePhase.playing);
+    expect(beforeQuit.movingForces, isNotEmpty);
+
+    controller.pauseGame();
+    controller.returnToConfiguration();
+
+    final settings = container.read(gameControllerProvider);
+    expect(settings.phase, GamePhase.configuration);
+    expect(settings.configuration, beforeQuit.configuration);
+    expect(settings.elapsedMs, 0);
+    expect(settings.selectedIslandId, isNull);
+    expect(settings.movingForces, isEmpty);
+    expect(settings.result, isNull);
+    expect(
+      settings.islands,
+      hasLength(beforeQuit.configuration.totalIslandCount),
+    );
+    expect(loop.isRunning, isFalse);
+  });
+
+  test('replays a result with the same island count and a new map', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.selectIslandCount(6);
+    final beforeReplay = container.read(gameControllerProvider);
+    controller.startGame();
+    completeStartCountdown(loop);
+    controller.finish(const GameResult.victory(elapsedMs: 25));
+
+    expect(container.read(gameControllerProvider).phase, GamePhase.result);
+    controller.replayGame();
+
+    final replay = container.read(gameControllerProvider);
+    expect(replay.phase, GamePhase.startCountdown);
+    expect(replay.configuration.totalIslandCount, 6);
+    expect(replay.islands, hasLength(6));
+    expect(replay.elapsedMs, 0);
+    expect(replay.movingForces, isEmpty);
+    expect(replay.islands, isNot(beforeReplay.islands));
+    expect(loop.isRunning, isTrue);
+  });
+
+  test('pauses an in-progress start countdown and resumes safely', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    loop.tick();
+    final countdown = container.read(gameControllerProvider);
+    expect(countdown.phase, GamePhase.startCountdown);
+    expect(countdown.countdownRemainingMs, 2950);
+
+    controller.pauseGame();
+    final paused = container.read(gameControllerProvider);
+    expect(paused.phase, GamePhase.paused);
+    expect(paused.countdownRemainingMs, 0);
+    expect(loop.isRunning, isFalse);
+
+    controller.resumeGame();
+    expect(
+      container.read(gameControllerProvider).phase,
+      GamePhase.resumeCountdown,
+    );
+    expect(container.read(gameControllerProvider).countdownRemainingMs, 3000);
+  });
 }

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -373,7 +373,11 @@ void main() {
         GamePhase.configuration,
         GamePhase.startCountdown,
       },
-      GamePhase.startCountdown: {GamePhase.startCountdown, GamePhase.playing},
+      GamePhase.startCountdown: {
+        GamePhase.startCountdown,
+        GamePhase.playing,
+        GamePhase.paused,
+      },
       GamePhase.playing: {
         GamePhase.playing,
         GamePhase.paused,
@@ -384,7 +388,11 @@ void main() {
         GamePhase.resumeCountdown,
         GamePhase.configuration,
       },
-      GamePhase.resumeCountdown: {GamePhase.resumeCountdown, GamePhase.playing},
+      GamePhase.resumeCountdown: {
+        GamePhase.resumeCountdown,
+        GamePhase.playing,
+        GamePhase.paused,
+      },
       GamePhase.result: {GamePhase.result, GamePhase.configuration},
     };
     for (final from in GamePhase.values) {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -479,4 +479,122 @@ void main() {
     expect(continued.elapsedMs, greaterThan(after.elapsedMs));
     expect(continued.movingForces.first.progress, greaterThan(0));
   });
+
+  testWidgets(
+    'pauses from the board and requires confirmation before quitting',
+    (tester) async {
+      final loop = ManualWidgetGameLoop();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gameLoopProvider.overrideWithValue(loop),
+            randomProvider.overrideWithValue(Random(1)),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('start-game')));
+      for (var index = 0; index < 60; index++) {
+        loop.tick();
+      }
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('pause-game')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('pause-game')));
+      await tester.pump();
+      expect(find.text('Game Paused'), findsOneWidget);
+      expect(find.byKey(const ValueKey('resume-game')), findsOneWidget);
+      expect(find.byKey(const ValueKey('quit-game')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('quit-game')));
+      await tester.pump();
+      expect(find.text('Quit match?'), findsOneWidget);
+      expect(find.byKey(const ValueKey('confirm-quit')), findsOneWidget);
+      expect(find.byKey(const ValueKey('cancel-quit')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('cancel-quit')));
+      await tester.pump();
+      expect(find.text('Game Paused'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('quit-game')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('confirm-quit')));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('start-game')), findsOneWidget);
+      expect(find.text('Game Paused'), findsNothing);
+    },
+  );
+
+  testWidgets('backgrounding a playing board pauses it automatically', (
+    tester,
+  ) async {
+    final loop = ManualWidgetGameLoop();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('start-game')));
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    loop.tick();
+    await tester.pump();
+    final before = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    ).read(gameControllerProvider);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    expect(find.text('Game Paused'), findsOneWidget);
+    expect(loop.isRunning, isFalse);
+
+    loop.tick();
+    await tester.pump();
+    final after = ProviderScope.containerOf(
+      tester.element(find.byKey(const ValueKey('island-0'))),
+    ).read(gameControllerProvider);
+    expect(after, before.copyWith(phase: GamePhase.paused));
+  });
+
+  testWidgets('result screen offers replay and settings actions', (
+    tester,
+  ) async {
+    final loop = ManualWidgetGameLoop();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    final islandFinder = find.byKey(const ValueKey('island-0'));
+    final container = ProviderScope.containerOf(tester.element(islandFinder));
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    controller.finish(const GameResult.victory(elapsedMs: 1));
+    await tester.pump();
+
+    expect(find.text('Victory'), findsOneWidget);
+    expect(find.byKey(const ValueKey('replay-game')), findsOneWidget);
+    expect(find.byKey(const ValueKey('return-settings')), findsOneWidget);
+    expect(loop.isRunning, isFalse);
+
+    await tester.tap(find.byKey(const ValueKey('return-settings')));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('start-game')), findsOneWidget);
+    expect(find.text('Victory'), findsNothing);
+  });
 }


### PR DESCRIPTION
## 概要

ゲーム中の一時停止、アプリのバックグラウンド移行時の自動停止、安全な再開カウントダウン、途中終了確認、勝敗結果と再戦導線を追加しました。停止中・結果表示後はGameLoopとCPUを含む全ゲーム状態の進行を止めます。

## 背景・目的

1人用ゲームでアプリとゲームのライフサイクルを一致させ、停止・再開・終了・再戦を安全に扱えるようにするための変更です。途中試合の永続化は追加していません。

## 対応内容

- プレイ中の手動一時停止とバックグラウンド移行時の自動停止
- 再開前の3、2、1カウントダウンとGameLoop・CPU判断の重複防止
- 一時停止メニューからの確認付き途中終了とキャンセル
- 勝利・敗北・引き分けの結果表示
- 同じ島数で新しいランダムマップを生成する再戦
- 島数設定画面への復帰
- controller、game rules、widget lifecycle/UIの回帰テスト
- 狭いviewportで再戦用マップを生成できない場合のfail-closed処理

## 主な設計判断

- pause中とresult確定後はcontroller/rules側でも進行を拒否し、UI非表示だけに依存しない停止境界にしました。
- 再開時は新しい3秒カウントダウンを開始し、既存GameLoopとCPU deadlineを安全に再利用・再設定して重複起動を防ぎます。
- 再戦用マップ生成が失敗した場合はcountdownやloopを開始せず設定状態へ戻します。
- 途中試合の永続化層はIssueの対象外のため追加していません。

## 受け入れ条件との対応

- [x] 一時停止中にゲーム内時間と全ゲーム状態が変化しない
- [x] バックグラウンド移行で自動的に一時停止する
- [x] 再開前に3秒カウントダウンを表示する
- [x] 再開後にGameLoopとCPU判断が重複起動しない
- [x] 途中終了は確認なしで実行されない
- [x] 終了キャンセルで試合へ戻れる
- [x] アプリ再起動時に途中試合を復元しない
- [x] 勝利・敗北・引き分けを区別して表示する
- [x] 結果表示後に兵力・部隊・CPU状態が変化しない
- [x] もう一度で同じ島数の新規マップを生成する
- [x] 設定へ戻るで島数を選び直せる
- [x] fvm flutter analyze と fvm flutter test が成功する

## 検証

- `fvm flutter analyze`: 成功
- `fvm flutter test`: 成功（89 tests）
- `fvm dart format --output=none --set-exit-if-changed <changed Dart files>`: 成功
- `git diff --check`: 成功
- `plutil -lint ios/Runner/Info.plist`: 成功
- `xmllint --noout <Android manifests>`: 成功
- `fvm flutter build apk --debug`: 成功
- `fvm flutter build ios --no-codesign`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `eefc2e3ed389b4553d19bfc2ecc84906685fac88`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `322586da59eb1b75031c6057f74f12f331c9c818`、fix HEAD: `eefc2e3ed389b4553d19bfc2ecc84906685fac88`）
- Required checks: 対象なし

## 残存リスク

実機でのOSバックグラウンド遷移は未実施です。widget lifecycle simulation、コード経路、Android/iOS buildで確認しています。リポジトリにrequired checksは設定されていません。

Closes #13