### PR TITLE
feat: プレイヤー操作と複数部隊アニメーションを実装する

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -158,7 +158,9 @@ class Base extends StatelessWidget {
     final value = base.faction == Faction.neutral
         ? 'durability ${base.currentDurability}'
         : 'forces ${base.currentForces} of ${base.capacity}';
-    final action = selected
+    final action = onPressed == null
+        ? 'interaction unavailable'
+        : selected
         ? 'selected dispatch source'
         : destinationCandidate
         ? 'valid dispatch destination'
@@ -169,7 +171,10 @@ class Base extends StatelessWidget {
         '${base.currentValue}, $action';
   }
 
-  String get _semanticHint {
+  String? get _semanticHint {
+    if (onPressed == null) {
+      return null;
+    }
     if (selected) {
       return 'Tap again to cancel selection, or choose a valid destination.';
     }

--- a/lib/base.dart
+++ b/lib/base.dart
@@ -9,10 +9,18 @@ import 'game/game_state.dart';
 /// repeats the faction and numeric values so the board remains usable without
 /// relying on color or visual inspection.
 class Base extends StatelessWidget {
-  const Base({required this.base, required this.onPressed, super.key});
+  const Base({
+    required this.base,
+    required this.onPressed,
+    this.selected = false,
+    this.destinationCandidate = false,
+    super.key,
+  });
 
   final IslandState base;
   final VoidCallback? onPressed;
+  final bool selected;
+  final bool destinationCandidate;
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +31,9 @@ class Base extends StatelessWidget {
       container: true,
       button: true,
       enabled: onPressed != null,
+      selected: selected,
       label: label,
+      hint: _semanticHint,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
           backgroundColor: _backgroundColor,
@@ -91,17 +101,31 @@ class Base extends StatelessWidget {
   }
 
   OutlinedBorder get _shape {
+    final outline = selected
+        ? const BorderSide(color: Colors.amber, width: 5)
+        : destinationCandidate
+        ? const BorderSide(color: Colors.cyanAccent, width: 4)
+        : null;
     return switch (base.faction) {
-      Faction.player => const CircleBorder(
-        side: BorderSide(color: Colors.white, width: 3),
-      ),
-      Faction.cpu => const BeveledRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(9)),
-        side: BorderSide(color: Colors.white, width: 3),
-      ),
-      Faction.neutral => const CircleBorder(
-        side: BorderSide(color: Colors.black, width: 2),
-      ),
+      Faction.player =>
+        const CircleBorder(
+          side: BorderSide(color: Colors.white, width: 3),
+        ).copyWith(
+          side: outline ?? const BorderSide(color: Colors.white, width: 3),
+        ),
+      Faction.cpu =>
+        const BeveledRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(9)),
+          side: BorderSide(color: Colors.white, width: 3),
+        ).copyWith(
+          side: outline ?? const BorderSide(color: Colors.white, width: 3),
+        ),
+      Faction.neutral =>
+        const CircleBorder(
+          side: BorderSide(color: Colors.black, width: 2),
+        ).copyWith(
+          side: outline ?? const BorderSide(color: Colors.black, width: 2),
+        ),
     };
   }
 
@@ -134,6 +158,27 @@ class Base extends StatelessWidget {
     final value = base.faction == Faction.neutral
         ? 'durability ${base.currentDurability}'
         : 'forces ${base.currentForces} of ${base.capacity}';
-    return '$_factionName $_sizeName, $value';
+    final action = selected
+        ? 'selected dispatch source'
+        : destinationCandidate
+        ? 'valid dispatch destination'
+        : base.canDispatch
+        ? 'available dispatch source'
+        : 'not available as dispatch source';
+    return '$_factionName $_sizeName, $value, current value '
+        '${base.currentValue}, $action';
+  }
+
+  String get _semanticHint {
+    if (selected) {
+      return 'Tap again to cancel selection, or choose a valid destination.';
+    }
+    if (destinationCandidate) {
+      return 'Tap to dispatch troops here.';
+    }
+    if (base.canDispatch) {
+      return 'Tap to select this island as a dispatch source.';
+    }
+    return 'This island cannot be selected as a dispatch source.';
   }
 }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -384,21 +384,12 @@ class GameController extends _$GameController {
     final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
     final phaseBeforeTick = state.phase;
     final selectedBeforeTick = state.selectedIslandId;
-    final selectedSourceBeforeTick = selectedBeforeTick == null
-        ? null
-        : _findIsland(selectedBeforeTick);
-    final selectionUnavailableBeforeTick =
-        selectedBeforeTick != null &&
-        (selectedSourceBeforeTick == null ||
-            !selectedSourceBeforeTick.canDispatch);
     final nextState = _rules.tick(state, deltaMs: deltaMs);
     state = nextState;
     if (phaseBeforeTick == GamePhase.playing &&
         selectedBeforeTick != null &&
         state.selectedIslandId == null &&
-        state.phase == GamePhase.playing &&
-        (selectionUnavailableBeforeTick ||
-            _selectionSourceIsUnavailable(selectedBeforeTick))) {
+        state.phase == GamePhase.playing) {
       _showInteractionFeedback(_invalidatedSourceMessage);
     }
     if (state.interactionFeedback != null &&
@@ -472,10 +463,5 @@ class GameController extends _$GameController {
       interactionFeedbackUntilMs:
           state.elapsedMs + _interactionFeedbackDurationMs,
     );
-  }
-
-  bool _selectionSourceIsUnavailable(int islandId) {
-    final island = _findIsland(islandId);
-    return island == null || !island.canDispatch;
   }
 }

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -53,6 +53,12 @@ class GameController extends _$GameController {
   GameConfiguration? _cachedConfiguration;
   GameState? _cachedInitialState;
 
+  static const _interactionFeedbackDurationMs = 1500;
+  static const _unavailableSourceMessage =
+      'Choose a player island with more than 1 force.';
+  static const _invalidatedSourceMessage =
+      'Dispatch unavailable: source needs more than 1 force and player ownership.';
+
   @override
   GameState build() {
     // Riverpod may invoke the disposal callbacks while rebuilding this
@@ -301,6 +307,7 @@ class GameController extends _$GameController {
             selectedSource.faction != Faction.player ||
             selectedSource.currentForces <= 1)) {
       state = state.clearSelection();
+      _showInteractionFeedback(_invalidatedSourceMessage);
       return;
     }
 
@@ -312,14 +319,17 @@ class GameController extends _$GameController {
     if (selectedIslandId == null) {
       if (tappedIsland.faction != Faction.player ||
           tappedIsland.currentForces <= 1) {
+        _showInteractionFeedback(_unavailableSourceMessage);
         return;
       }
-      state = state.copyWith(selectedIslandId: baseId);
+      state = state
+          .copyWith(selectedIslandId: baseId)
+          .clearInteractionFeedback();
       return;
     }
 
     if (selectedIslandId == baseId) {
-      state = state.clearSelection();
+      state = state.clearSelection().clearInteractionFeedback();
       return;
     }
 
@@ -327,6 +337,7 @@ class GameController extends _$GameController {
     final strength = source.currentForces ~/ 2;
     if (strength <= 0) {
       state = state.clearSelection();
+      _showInteractionFeedback(_invalidatedSourceMessage);
       return;
     }
 
@@ -350,7 +361,8 @@ class GameController extends _$GameController {
 
     state = state
         .copyWith(islands: islands, movingForces: movingForces)
-        .clearSelection();
+        .clearSelection()
+        .clearInteractionFeedback();
   }
 
   void _tick() {
@@ -371,8 +383,28 @@ class GameController extends _$GameController {
         : now - previous;
     final deltaMs = measuredDelta > 0 ? measuredDelta : 50;
     final phaseBeforeTick = state.phase;
+    final selectedBeforeTick = state.selectedIslandId;
+    final selectedSourceBeforeTick = selectedBeforeTick == null
+        ? null
+        : _findIsland(selectedBeforeTick);
+    final selectionUnavailableBeforeTick =
+        selectedBeforeTick != null &&
+        (selectedSourceBeforeTick == null ||
+            !selectedSourceBeforeTick.canDispatch);
     final nextState = _rules.tick(state, deltaMs: deltaMs);
     state = nextState;
+    if (phaseBeforeTick == GamePhase.playing &&
+        selectedBeforeTick != null &&
+        state.selectedIslandId == null &&
+        state.phase == GamePhase.playing &&
+        (selectionUnavailableBeforeTick ||
+            _selectionSourceIsUnavailable(selectedBeforeTick))) {
+      _showInteractionFeedback(_invalidatedSourceMessage);
+    }
+    if (state.interactionFeedback != null &&
+        state.elapsedMs >= state.interactionFeedbackUntilMs) {
+      state = state.clearInteractionFeedback();
+    }
     if (state.phase == GamePhase.playing) {
       if (phaseBeforeTick == GamePhase.startCountdown) {
         // The initial match has no pending CPU deadline yet.  A resume
@@ -432,5 +464,18 @@ class GameController extends _$GameController {
       maxId = max(maxId, force.id);
     }
     return maxId + 1;
+  }
+
+  void _showInteractionFeedback(String message) {
+    state = state.copyWith(
+      interactionFeedback: message,
+      interactionFeedbackUntilMs:
+          state.elapsedMs + _interactionFeedbackDurationMs,
+    );
+  }
+
+  bool _selectionSourceIsUnavailable(int islandId) {
+    final island = _findIsland(islandId);
+    return island == null || !island.canDispatch;
   }
 }

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -184,6 +184,17 @@ class IslandState {
   int get forces => currentForces;
   int get currentStrength => currentForces;
 
+  /// The value currently displayed for this island, regardless of whether it
+  /// is an owned island's forces or a neutral island's durability.
+  int get currentValue =>
+      faction == Faction.neutral ? currentDurability : currentForces;
+
+  /// Whether this island can be selected as a player dispatch source.
+  bool get canDispatch => faction == Faction.player && currentForces > 1;
+
+  /// A descriptive alias used by accessibility-facing board code.
+  bool get actionAvailable => canDispatch;
+
   /// Canonical alias for the neutral-island value.
   int get currentDurability => durability;
 
@@ -326,6 +337,13 @@ class MovingForce {
   int get sourceBaseId => sourceIslandId;
   int get targetBaseId => destinationIslandId;
   int get scale => strength;
+
+  /// The value rendered on a moving troop marker.
+  int get currentValue => strength;
+
+  /// Moving troops have no player action of their own.
+  bool get actionAvailable => false;
+  bool get isTappable => false;
 
   MovingForce copyWith({
     int? id,
@@ -482,6 +500,8 @@ final class GameState {
     int? selectedBaseId,
     List<MovingForce>? movingForces,
     MovingForce? movement,
+    String? interactionFeedback,
+    int interactionFeedbackUntilMs = 0,
     GameResult? result,
     int? countdownRemainingMs,
   }) : configuration = configuration ?? GameConfiguration.initial,
@@ -493,6 +513,8 @@ final class GameState {
                  ? const <MovingForce>[]
                  : <MovingForce>[movement]),
        ),
+       interactionFeedback = interactionFeedback,
+       interactionFeedbackUntilMs = interactionFeedbackUntilMs,
        result = result,
        countdownRemainingMs = countdownRemainingMs ?? 0 {
     if ((phase == GamePhase.result) != (result != null)) {
@@ -508,6 +530,8 @@ final class GameState {
   final List<IslandState> islands;
   final int? selectedIslandId;
   final List<MovingForce> movingForces;
+  final String? interactionFeedback;
+  final int interactionFeedbackUntilMs;
   final GameResult? result;
   final int countdownRemainingMs;
 
@@ -515,6 +539,12 @@ final class GameState {
   List<IslandState> get bases => islands;
   int? get selectedBaseId => selectedIslandId;
   MovingForce? get movement => movingForces.isEmpty ? null : movingForces.first;
+
+  bool get hasInteractionFeedback =>
+      interactionFeedback != null && elapsedMs < interactionFeedbackUntilMs;
+
+  /// Compatibility alias for callers that use the shorter feedback name.
+  String? get feedback => interactionFeedback;
 
   bool get isCountdown =>
       phase == GamePhase.startCountdown || phase == GamePhase.resumeCountdown;
@@ -528,6 +558,8 @@ final class GameState {
     int? selectedIslandId,
     int? selectedBaseId,
     List<MovingForce>? movingForces,
+    String? interactionFeedback,
+    int? interactionFeedbackUntilMs,
     GameResult? result,
     int? countdownRemainingMs,
   }) {
@@ -539,6 +571,9 @@ final class GameState {
       selectedIslandId:
           selectedIslandId ?? selectedBaseId ?? this.selectedIslandId,
       movingForces: movingForces ?? this.movingForces,
+      interactionFeedback: interactionFeedback ?? this.interactionFeedback,
+      interactionFeedbackUntilMs:
+          interactionFeedbackUntilMs ?? this.interactionFeedbackUntilMs,
       result: result ?? this.result,
       countdownRemainingMs: countdownRemainingMs ?? this.countdownRemainingMs,
     );
@@ -554,6 +589,8 @@ final class GameState {
       islands: islands,
       selectedIslandId: selectedIslandId,
       movingForces: movingForces,
+      interactionFeedback: interactionFeedback,
+      interactionFeedbackUntilMs: interactionFeedbackUntilMs,
       result: nextResult,
       countdownRemainingMs: 0,
     );
@@ -579,6 +616,8 @@ final class GameState {
       islands: islands,
       selectedIslandId: selectedIslandId,
       movingForces: movingForces,
+      interactionFeedback: interactionFeedback,
+      interactionFeedbackUntilMs: interactionFeedbackUntilMs,
       result: null,
       countdownRemainingMs: countdownRemainingMs,
     );
@@ -594,6 +633,8 @@ final class GameState {
       islands: islands,
       selectedIslandId: null,
       movingForces: movingForces,
+      interactionFeedback: interactionFeedback,
+      interactionFeedbackUntilMs: interactionFeedbackUntilMs,
       result: result,
       countdownRemainingMs: countdownRemainingMs,
     );
@@ -608,6 +649,8 @@ final class GameState {
       islands: islands,
       selectedIslandId: selectedIslandId,
       movingForces: const <MovingForce>[],
+      interactionFeedback: interactionFeedback,
+      interactionFeedbackUntilMs: interactionFeedbackUntilMs,
       result: result,
       countdownRemainingMs: countdownRemainingMs,
     );
@@ -626,6 +669,8 @@ final class GameState {
       islands: islands,
       selectedIslandId: selectedIslandId,
       movingForces: movingForces,
+      interactionFeedback: interactionFeedback,
+      interactionFeedbackUntilMs: interactionFeedbackUntilMs,
       result: null,
       countdownRemainingMs: countdownRemainingMs,
     );
@@ -639,6 +684,22 @@ final class GameState {
         : copyWith(movingForces: <MovingForce>[movement]);
   }
 
+  /// Removes transient interaction feedback without changing the match.
+  GameState clearInteractionFeedback() {
+    return GameState(
+      configuration: configuration,
+      phase: phase,
+      elapsedMs: elapsedMs,
+      islands: islands,
+      selectedIslandId: selectedIslandId,
+      movingForces: movingForces,
+      interactionFeedback: null,
+      interactionFeedbackUntilMs: 0,
+      result: result,
+      countdownRemainingMs: countdownRemainingMs,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     return other is GameState &&
@@ -648,6 +709,8 @@ final class GameState {
         _listEquals(other.islands, islands) &&
         other.selectedIslandId == selectedIslandId &&
         _listEquals(other.movingForces, movingForces) &&
+        other.interactionFeedback == interactionFeedback &&
+        other.interactionFeedbackUntilMs == interactionFeedbackUntilMs &&
         other.result == result &&
         other.countdownRemainingMs == countdownRemainingMs;
   }
@@ -660,6 +723,8 @@ final class GameState {
     Object.hashAll(islands),
     selectedIslandId,
     Object.hashAll(movingForces),
+    interactionFeedback,
+    interactionFeedbackUntilMs,
     result,
     countdownRemainingMs,
   );

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,4 +1,5 @@
 import 'package:conquest/base.dart';
+import 'package:conquest/moving_force.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -88,15 +89,30 @@ class _GameSurfaceState extends ConsumerState<_GameSurface>
                     child: Base(
                       key: ValueKey('island-button-${island.id}'),
                       base: island,
+                      selected: state.selectedIslandId == island.id,
+                      destinationCandidate:
+                          state.selectedIslandId != null &&
+                          state.selectedIslandId != island.id,
                       onPressed: state.phase == GamePhase.playing
                           ? () => controller.tapBase(island.id)
                           : null,
                     ),
                   ),
                 ),
+              for (final force in state.movingForces)
+                Align(
+                  key: ValueKey('moving-force-position-${force.id}'),
+                  alignment: Alignment(force.x, force.y),
+                  child: MovingForceWidget(
+                    force: force,
+                    semanticsKey: ValueKey('moving-force-${force.id}'),
+                  ),
+                ),
             ],
           ),
         ),
+        if (state.hasInteractionFeedback)
+          _InteractionFeedback(message: state.interactionFeedback!),
         if (state.phase == GamePhase.configuration && state.islands.isNotEmpty)
           _ConfigurationPanel(state: state, onStart: controller.startGame),
         if (state.phase == GamePhase.playing)
@@ -431,5 +447,50 @@ class _CountdownBanner extends StatelessWidget {
       return 'START';
     }
     return null;
+  }
+}
+
+class _InteractionFeedback extends StatelessWidget {
+  const _InteractionFeedback({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+          child: Semantics(
+            container: true,
+            liveRegion: true,
+            label: message,
+            child: DecoratedBox(
+              key: const ValueKey('interaction-feedback'),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.86),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.amberAccent, width: 2),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                child: Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/moving_force.dart
+++ b/lib/moving_force.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import 'game/game_rules.dart';
+import 'game/game_state.dart';
+
+/// Renders one immutable in-flight troop group.
+///
+/// The marker is deliberately not a button.  [IgnorePointer] keeps a moving
+/// troop from intercepting taps intended for an island underneath it, while
+/// the semantics node still exposes its faction and current strength.
+class MovingForceWidget extends StatelessWidget {
+  const MovingForceWidget({required this.force, this.semanticsKey, super.key});
+
+  static const size = GameRules.movingForceWidgetSize;
+
+  final MovingForce force;
+  final Key? semanticsKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      key: semanticsKey,
+      container: true,
+      excludeSemantics: true,
+      enabled: false,
+      label: _semanticLabel,
+      child: IgnorePointer(
+        child: SizedBox.square(
+          dimension: size,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: _backgroundColor,
+              shape: force.faction == Faction.cpu
+                  ? BoxShape.rectangle
+                  : BoxShape.circle,
+              border: Border.all(color: _outlineColor, width: 2.5),
+              borderRadius: force.faction == Faction.cpu
+                  ? BorderRadius.circular(5)
+                  : null,
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black38,
+                  blurRadius: 2,
+                  offset: Offset(0, 1),
+                ),
+              ],
+            ),
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _marker,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 8,
+                      fontWeight: FontWeight.w900,
+                      height: 1,
+                    ),
+                  ),
+                  Text(
+                    force.currentValue.toString(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w900,
+                      height: 1.05,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color get _backgroundColor {
+    return switch (force.faction) {
+      Faction.player => Colors.green.shade800,
+      Faction.cpu => Colors.red.shade800,
+      Faction.neutral => Colors.grey.shade800,
+    };
+  }
+
+  Color get _outlineColor {
+    return switch (force.faction) {
+      Faction.player => Colors.lightGreenAccent,
+      Faction.cpu => Colors.orangeAccent,
+      Faction.neutral => Colors.white,
+    };
+  }
+
+  String get _marker {
+    return switch (force.faction) {
+      Faction.player => 'P',
+      Faction.cpu => 'C',
+      Faction.neutral => 'N',
+    };
+  }
+
+  String get _factionName {
+    return switch (force.faction) {
+      Faction.player => 'Player',
+      Faction.cpu => 'CPU',
+      Faction.neutral => 'Neutral',
+    };
+  }
+
+  String get _semanticLabel {
+    return '$_factionName moving troop, strength ${force.currentValue}, '
+        'current value ${force.currentValue}, '
+        'from island ${force.sourceIslandId} to island '
+        '${force.destinationIslandId}, action unavailable, not tappable';
+  }
+}
+
+/// Alternate name for code that calls an in-flight group a moving force view.
+typedef MovingForceView = MovingForceWidget;

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -259,6 +259,83 @@ void main() {
   );
 
   test(
+    'shows feedback when a selected source is cleared and reoccupied in one tick',
+    () {
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
+      completeStartCountdown(loop);
+
+      controller.state = GameState(
+        phase: GamePhase.playing,
+        elapsedMs: 0,
+        selectedIslandId: 0,
+        islands: const [
+          IslandState(
+            id: 0,
+            faction: Faction.player,
+            size: IslandSize.small,
+            currentForces: 3,
+            capacity: 50,
+          ),
+          IslandState(
+            id: 1,
+            faction: Faction.cpu,
+            size: IslandSize.small,
+            currentForces: 10,
+            capacity: 50,
+          ),
+          IslandState(
+            id: 2,
+            faction: Faction.player,
+            size: IslandSize.small,
+            currentForces: 10,
+            capacity: 50,
+          ),
+        ],
+        movingForces: const [
+          MovingForce(
+            id: 0,
+            faction: Faction.cpu,
+            sourceIslandId: 1,
+            destinationIslandId: 0,
+            strength: 10,
+            arrivalTimeMs: 1,
+            durationMs: 1,
+          ),
+          MovingForce(
+            id: 1,
+            faction: Faction.player,
+            sourceIslandId: 2,
+            destinationIslandId: 0,
+            strength: 9,
+            arrivalTimeMs: 2,
+            durationMs: 1,
+          ),
+        ],
+      );
+
+      loop.tick();
+
+      final afterTick = container.read(gameControllerProvider);
+      final source = afterTick.islands.firstWhere((island) => island.id == 0);
+      expect(afterTick.phase, GamePhase.playing);
+      expect(source.faction, Faction.player);
+      expect(source.currentForces, 2);
+      expect(afterTick.selectedIslandId, isNull);
+      expect(afterTick.interactionFeedback, contains('Dispatch unavailable'));
+      expect(afterTick.hasInteractionFeedback, isTrue);
+
+      for (var index = 0; index < 30; index++) {
+        loop.tick();
+      }
+      expect(
+        container.read(gameControllerProvider).interactionFeedback,
+        isNull,
+      );
+    },
+  );
+
+  test(
     'dispatches floor half for zero, one, even, odd, and maximum forces',
     () {
       final controller = container.read(gameControllerProvider.notifier);

--- a/test/game_controller_test.dart
+++ b/test/game_controller_test.dart
@@ -190,6 +190,37 @@ void main() {
     },
   );
 
+  test('reports unavailable feedback for non-player and exhausted sources', () {
+    final controller = container.read(gameControllerProvider.notifier);
+    controller.startGame();
+    completeStartCountdown(loop);
+
+    controller.tapBase(1);
+    var state = container.read(gameControllerProvider);
+    expect(state.selectedIslandId, isNull);
+    expect(state.interactionFeedback, contains('player island'));
+
+    controller.tapBase(0);
+    state = container.read(gameControllerProvider);
+    expect(state.selectedIslandId, 0);
+    controller.state = state.copyWith(
+      islands: [
+        for (final island in state.islands)
+          island.id == 0 ? island.copyWith(currentForces: 1) : island,
+      ],
+    );
+    controller.tapBase(2);
+
+    state = container.read(gameControllerProvider);
+    expect(state.selectedIslandId, isNull);
+    expect(state.interactionFeedback, contains('more than 1'));
+
+    for (var index = 0; index < 30; index++) {
+      loop.tick();
+    }
+    expect(container.read(gameControllerProvider).interactionFeedback, isNull);
+  });
+
   test(
     'uses force at destination tap time and clears an invalid selection',
     () {
@@ -221,7 +252,9 @@ void main() {
       );
       loop.tick();
 
-      expect(container.read(gameControllerProvider).selectedIslandId, isNull);
+      final cleared = container.read(gameControllerProvider);
+      expect(cleared.selectedIslandId, isNull);
+      expect(cleared.interactionFeedback, contains('more than 1'));
     },
   );
 

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -48,6 +48,48 @@ void main() {
   });
 
   test(
+    'islands and moving forces expose current values and action availability',
+    () {
+      const player = IslandState(
+        id: 0,
+        faction: Faction.player,
+        currentForces: 8,
+        capacity: 50,
+      );
+      const exhausted = IslandState(
+        id: 1,
+        faction: Faction.player,
+        currentForces: 1,
+        capacity: 50,
+      );
+      const neutral = IslandState(
+        id: 2,
+        faction: Faction.neutral,
+        durability: 7,
+        currentForces: 0,
+        capacity: 50,
+      );
+      const force = MovingForce(
+        id: 3,
+        faction: Faction.cpu,
+        sourceIslandId: 1,
+        destinationIslandId: 0,
+        strength: 4,
+      );
+
+      expect(player.currentValue, 8);
+      expect(player.canDispatch, isTrue);
+      expect(player.actionAvailable, isTrue);
+      expect(exhausted.canDispatch, isFalse);
+      expect(neutral.currentValue, 7);
+      expect(neutral.actionAvailable, isFalse);
+      expect(force.currentValue, 4);
+      expect(force.actionAvailable, isFalse);
+      expect(force.isTappable, isFalse);
+    },
+  );
+
+  test(
     'initial neutral island composition carries typed durability values',
     () {
       const expectedSizes = <int, List<IslandSize>>{

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,11 +1,13 @@
 import 'dart:math';
 
+import 'package:conquest/base.dart';
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_loop.dart';
 import 'package:conquest/game/game_rules.dart';
 import 'package:conquest/game/game_state.dart';
 import 'package:conquest/home.dart';
 import 'package:conquest/main.dart';
+import 'package:conquest/moving_force.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -157,6 +159,153 @@ void main() {
     );
     semantics.dispose();
   });
+
+  testWidgets('shows the selected source and valid destination candidates', (
+    tester,
+  ) async {
+    final loop = ManualWidgetGameLoop();
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('start-game')));
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('island-button-0')));
+    await tester.pump();
+
+    final source = tester.getSemantics(
+      find.byKey(const ValueKey('island-button-0')),
+    );
+    final destination = tester.getSemantics(
+      find.byKey(const ValueKey('island-button-2')),
+    );
+    expect(
+      tester
+          .widget<Base>(find.byKey(const ValueKey('island-button-0')))
+          .selected,
+      isTrue,
+    );
+    expect(source.label, contains('selected dispatch source'));
+    expect(destination.label, contains('valid dispatch destination'));
+    semantics.dispose();
+  });
+
+  testWidgets('shows unavailable interaction feedback on the board', (
+    tester,
+  ) async {
+    final loop = ManualWidgetGameLoop();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gameLoopProvider.overrideWithValue(loop),
+          randomProvider.overrideWithValue(Random(1)),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('start-game')));
+    for (var index = 0; index < 60; index++) {
+      loop.tick();
+    }
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('island-button-1')));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('interaction-feedback')), findsOneWidget);
+    expect(find.textContaining('player island'), findsOneWidget);
+  });
+
+  testWidgets(
+    'renders every moving force with faction and strength semantics',
+    (tester) async {
+      final loop = ManualWidgetGameLoop();
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gameLoopProvider.overrideWithValue(loop),
+            randomProvider.overrideWithValue(Random(1)),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      final islandFinder = find.byKey(const ValueKey('island-button-0'));
+      final container = ProviderScope.containerOf(tester.element(islandFinder));
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.startGame();
+      for (var index = 0; index < 60; index++) {
+        loop.tick();
+      }
+      final state = container.read(gameControllerProvider);
+      controller.state = state.copyWith(
+        movingForces: [
+          const MovingForce(
+            id: 101,
+            faction: Faction.player,
+            sourceIslandId: 0,
+            destinationIslandId: 2,
+            strength: 17,
+            position: IslandPosition(x: 0, y: 0),
+          ),
+          const MovingForce(
+            id: 102,
+            faction: Faction.cpu,
+            sourceIslandId: 1,
+            destinationIslandId: 3,
+            strength: 9,
+            position: IslandPosition(x: 0.25, y: -0.25),
+          ),
+        ],
+      );
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('moving-force-101')), findsOneWidget);
+      expect(find.byKey(const ValueKey('moving-force-102')), findsOneWidget);
+      expect(
+        tester
+            .getSemantics(find.byKey(const ValueKey('moving-force-101')))
+            .label,
+        allOf(
+          contains('Player'),
+          contains('strength 17'),
+          contains('not tappable'),
+        ),
+      );
+      expect(
+        tester
+            .getSemantics(find.byKey(const ValueKey('moving-force-102')))
+            .label,
+        allOf(
+          contains('CPU'),
+          contains('strength 9'),
+          contains('not tappable'),
+        ),
+      );
+      expect(
+        tester.getSemantics(find.byType(MovingForceWidget).first).label,
+        contains('Player moving troop'),
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('moving-force-101')),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      expect(container.read(gameControllerProvider).selectedIslandId, isNull);
+      semantics.dispose();
+    },
+  );
 
   testWidgets('keeps every island-count preset physically operable', (
     tester,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' show SemanticsAction, Tristate;
 import 'dart:math';
 
 import 'package:conquest/base.dart';
@@ -159,6 +160,67 @@ void main() {
     );
     semantics.dispose();
   });
+
+  testWidgets(
+    'does not advertise island actions while the board is not playable',
+    (tester) async {
+      final loop = ManualWidgetGameLoop();
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gameLoopProvider.overrideWithValue(loop),
+            randomProvider.overrideWithValue(Random(1)),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      final islandFinder = find.byKey(const ValueKey('island-button-0'));
+      final container = ProviderScope.containerOf(tester.element(islandFinder));
+
+      void expectDisabledIslandSemantics() {
+        final node = tester.getSemantics(islandFinder);
+        final data = node.getSemanticsData();
+        expect(data.flagsCollection.isEnabled, Tristate.isFalse);
+        expect(data.hasAction(SemanticsAction.tap), isFalse);
+        expect(node.hint, isNot(contains('Tap')));
+        expect(node.label, isNot(contains('available dispatch source')));
+        expect(node.label, isNot(contains('selected dispatch source')));
+        expect(node.label, isNot(contains('valid dispatch destination')));
+      }
+
+      // Configuration state renders player-owned islands before interaction
+      // is enabled, even though the island itself has enough forces.
+      expectDisabledIslandSemantics();
+
+      await tester.tap(find.byKey(const ValueKey('start-game')));
+      await tester.pump();
+      // The map remains visible during the start countdown, but callbacks are
+      // still disabled until the countdown reaches the playing phase.
+      expectDisabledIslandSemantics();
+
+      for (var index = 0; index < 60; index++) {
+        loop.tick();
+      }
+      await tester.pump();
+
+      final playingNode = tester.getSemantics(islandFinder);
+      final playingData = playingNode.getSemanticsData();
+      expect(playingData.flagsCollection.isEnabled, Tristate.isTrue);
+      expect(tester.widget<Base>(islandFinder).onPressed, isNotNull);
+      expect(playingNode.label, contains('available dispatch source'));
+      expect(playingNode.hint, contains('Tap to select'));
+
+      final controller = container.read(gameControllerProvider.notifier);
+      controller.tapBase(0);
+      controller.pauseGame();
+      await tester.pump();
+      // Pausing disables the callback while preserving the selected state.
+      expectDisabledIslandSemantics();
+      semantics.dispose();
+    },
+  );
 
   testWidgets('shows the selected source and valid destination candidates', (
     tester,


### PR DESCRIPTION
## 概要

自軍島の選択・解除・出兵操作と、選択候補・出兵不可フィードバックを盤面へ追加しました。すべての移動中部隊を距離比例位置へ同時描画し、色に加えて陣営マーク・輪郭・兵力・Semanticsで識別できるようにしています。

## 背景・目的

Issue #14 のゲームエンジン状態を、誤操作しにくくアクセシブルな盤面操作と複数部隊アニメーションとして公開します。

## 対応内容

- 自軍島の選択、再タップ解除、増援・攻撃の共通タップ出兵を実装
- 選択島と有効な移動先候補を視覚的に区別
- 所有権喪失・兵力不足による自動解除と短時間フィードバックを実装
- 全移動部隊を独立した非タップ対象として同時描画
- 島と部隊に陣営、現在値、操作可否のSemanticsを追加
- 同一tick内の一時占領後再占領でも自動解除フィードバックを保持する回帰テストを追加

## 主な設計判断

- 既存の `GameRules` / `GameController` の選択・出兵・距離比例移動をsource of truthとし、UIは状態から選択候補と部隊位置を導出します。
- 陣営表示はゲームルールどおり色だけに依存せず、記号と輪郭を併用します。
- 移動部隊はSemantics情報を公開しますがタップ対象にはしません。

## 受け入れ条件との対応

- [x] 自軍島だけを出兵元として選択できる
- [x] 選択、解除、出兵成立、自動解除が状態と表示で一致する
- [x] 選択中の島と移動先候補を視覚的に識別できる
- [x] 兵力1以下や所有権喪失時に出兵せずフィードバックを表示する
- [x] 自軍島への増援と中立・敵島への攻撃を同じ操作で行える
- [x] 同じ島から連続して複数部隊を送り出せる
- [x] 複数部隊が互いに上書きされず同時表示される
- [x] 両軍の移動部隊について陣営と兵力を確認できる
- [x] 到着した部隊だけが画面から消える
- [x] 島と部隊のSemanticsから所属・現在値・操作可否を取得できる
- [x] `fvm flutter analyze` と `fvm flutter test` が成功する

## 検証

- `fvm flutter test`: 成功（95 tests）
- `fvm flutter analyze`: 成功（No issues found）
- `fvm dart format --output=none --set-exit-if-changed lib test`: 成功
- `git diff --check`: 成功
- `fvm flutter build apk --debug`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `cfe06a1231d3ecbc15d0d4f50b95fbec5ebefcc6`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `cfe06a1231d3ecbc15d0d4f50b95fbec5ebefcc6`、fix HEAD: `fd8af5900d52a654174f2fac8a4ab067180a1fa5`）
- Required checks: 対象なし

## 残存リスク

実機上の統合QAはIssue #15で実施します。Issue #14のコード・既存契約上の未解決リスクはありません。

Closes #14
