### PR TITLE
test: 初期版CPU戦の統合テストと端末QAを完了する

### DIFF
--- a/docs/integration-qa.md
+++ b/docs/integration-qa.md
@@ -5,8 +5,8 @@
 
 ## 実施環境
 
-- 実施日時: 2026-08-05 14:29–14:35 JST（05:29–05:35 UTC）
-- checkout: `codex/issue-15-integration-qa`, 実施開始時のHEAD `62521a1`
+- 実施日時: 2026-08-05 14:29–15:15 JST（05:29–06:15 UTC）
+- checkout: `codex/issue-15-integration-qa`, 実施開始時のHEAD `74fdb47`
 - host: macOS 26.5.2 / Darwin arm64（`uname -a`: Darwin 25.5.0）
 - Flutter: 3.44.8、Dart 3.12.2（FVM 2.2.6）
 - Xcode: 26.6 (17F113)
@@ -17,6 +17,16 @@
   `da4017d0b3b0ed62fa45df3beee2e438c5caaf3de6544a6afae393693d0f9040`
   （`/tmp/conquest-issue-15-board.png`）。一時的なSimulator画面であり、個別の
   画像ファイルを成果物に含める必要はないためcommitしていない。
+- 実時間端末テスト: `fvm flutter test integration_test/issue_15_device_qa_test.dart
+  -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AEF7` を実行。15:05:05 JSTのplaying開始確認から
+  15:15:56 JSTのrunner完了まで10分51秒を観測し、runner実行時間は11分13秒、テスト内の
+  wall-clock計測も10分以上をassertした。開始画面のSHA-256は
+  `423c0c7d7e75ef9c4e7644f3eb3479b445dc081ef9f620245c454c5397c56059`
+  （`/tmp/conquest-issue-15-integration-start.png`）。
+- iOS integration_testの実行時にFlutter 3.44.8が追加する
+  `FlutterGeneratedPluginSwiftPackage`のpbxproj/scheme移行は、2回目のiOS simulator
+  buildで追加diffが発生しないことを確認したため、テスト依存を再現するin-scopeの
+  build設定としてcommitする。
 
 ## 統合自動テスト
 
@@ -33,7 +43,8 @@
 | 同時到着による引き分け、結果後の停止 | `resolves a draw from simultaneous equal arrivals and freezes the loop` | PASS |
 | 自軍増援の上限、中立の同数攻撃、敵島の超過攻撃 | `keeps friendly, neutral, and enemy boundary arrivals independent` | PASS |
 | 一時停止、再開カウントダウン、結果、再戦、provider破棄 | `pauses, resumes, rematches, and disposes without advancing state` | PASS |
-| 多数部隊の同時存在、取りこぼし・上書きなし | `handles many simultaneous troops without dropping or overwriting them` | PASS |
+| CPU防衛の予測、Controller経由の出兵、到着、占領阻止 | `dispatches CPU defense before a threatened island can be occupied` | PASS |
+| 非対称な多数部隊、複数対象、異なる到着時刻、残存部隊 | `processes asymmetric troops across targets and arrival times exactly` | PASS |
 
 個別ルールの境界値は既存テストでも確認している。`test/game_rules_test.dart` の
 成長境界・容量上限・移動時間・中立/敵の不足/同数/超過・同時到着・最後の島喪失後の
@@ -53,16 +64,16 @@ Flutter debugアプリを `fvm flutter run -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AE
 | Safe Areaとタップ領域 | PASS | countdown画面の本陣・中立島がノッチ/下端内側に配置。playing中にプレイヤー本陣をタップできた。 |
 | 島のサイズ・所属・現在値・上限値 | PASS | AXでheadquarters `forces N of 200`、small/medium/largeの所属、耐久値、上限値を確認。 |
 | 選択・解除・無効フィードバック | PARTIAL | playing中に`selected dispatch source`と有効な移動先表示を確認。解除/無効メッセージの自動テストはPASS。 |
-| 両軍の複数移動部隊 | PASS | playing中にAXでCPU moving troopを複数確認。200部隊の統合自動テストもPASS。 |
+| 両軍の複数移動部隊 | PASS | playing中にAXでCPU moving troopを複数確認。220部隊の統合自動テストもPASS。 |
 | カウントダウン | PASS | AX/画面で`Game start 3`を確認し、完了後にPAUSEと操作可能な島を確認。 |
 | 一時停止 | PASS | PAUSEをタップし、`Game Paused`、`RESUME`、`QUIT MATCH`を確認。 |
 | 再開 | PASS | RESUME後に`Game start 3`を確認し、playingへ復帰。 |
 | 結果画面 | PASS | CPU進行後に`Defeat`、`PLAY AGAIN`、`RETURN TO SETTINGS`を確認。 |
 | 再戦 | PASS | `PLAY AGAIN`後に同じ10島数の新マップとカウントダウンを確認。 |
 | 色以外の陣営識別 | PASS | AXでPlayer/CPU/Neutralのラベル、`P`/`C`/`N`マーク、数値を確認。 |
-| 長時間試合の操作性・描画安定性 | 未手動 | 長時間の実時間試合は実施せず、固定時間の成長境界・CPU進行・多数部隊を自動テストで代替。 |
+| 長時間試合の操作性・描画安定性 | PASS | iPhone 17 Simulatorで12島をSTARTし、冒頭と10秒間隔の出兵、3回のPAUSE→2秒停止確認→RESUME（約1/5/8分）、結果時の再戦回復分岐を監視。`Future.delayed`で10分以上の実時間を確保し、各観測で`pump`して連続描画を確認。テスト終了はexit 0 / `All tests passed!`、dispatch 2回以上・pause/resume 2回以上・Flutter framework exception 0件をassert。15:14:57 JSTの終盤スクリーンショットでもplaying/PAUSEを確認し、runner teardown後はSimulatorホーム画面へ戻った。 |
 | バックグラウンド自動一時停止 | 未手動 | Simulatorでのホーム遷移は今回実施せず。`test/widget_test.dart` の`backgrounding a playing board pauses it automatically`でライフサイクル通知を検証。 |
-| 移動先タップによる実端末出兵 | 未手動 | CPUの再描画でAX element IDが短時間に更新され、今回のComputer Use操作ではdestination dispatchの安定した証跡を取得できなかった。`test/widget_test.dart` と `test/game_controller_test.dart` のタップ自動テストで補完。 |
+| 移動先タップによる実端末出兵 | PASS | `integration_test/issue_15_device_qa_test.dart` がiPhone 17上でsource/destinationを実際にtapし、複数dispatchと移動部隊描画をassert。手動AX操作はCPU再描画でIDが更新されたため補完扱い。 |
 
 ## `game-rules.md` 対応表
 
@@ -75,7 +86,7 @@ Flutter debugアプリを `fvm flutter run -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AE
 | 島選択、半分切り捨て、選択解除、繰り返し出兵、複数部隊 | `game_controller_test.dart` のselection/dispatch/multiple troops、`widget_test.dart` のsemantics、統合多数部隊 |
 | 移動速度、距離比例、到着時のみ処理 | `game_rules_test.dart` のmovement duration/arrival tests、統合境界到着 |
 | 自軍増援、中立/敵の不足・同数・超過、残存兵力上限、同時到着 | `game_rules_test.dart` のcombat tests、`integration_qa_test.dart` のboundary/simultaneous tests |
-| CPU間隔、1判断1部隊、防衛、攻撃/出兵元優先、到着予測 | `cpu_strategy_test.dart` 全体、`cpu_controller_integration_test.dart`、固定乱数CPU統合 |
+| CPU間隔、1判断1部隊、防衛、攻撃/出兵元優先、到着予測 | `cpu_strategy_test.dart` 全体、`cpu_controller_integration_test.dart`、`integration_qa_test.dart`のController防衛統合 |
 | 表示値、選択枠、移動部隊値、無効フィードバック | `widget_test.dart` のsemantics/feedback/moving-force tests、端末AX観測 |
 | 一時停止、バックグラウンド、再開、途中終了、未保存 | `game_controller_test.dart`、`widget_test.dart` のpause/quit/lifecycle、統合pause/resume/dispose |
 | 結果停止、もう一度、設定へ戻る | `game_controller_test.dart`、`widget_test.dart`、統合result/rematch |

--- a/docs/integration-qa.md
+++ b/docs/integration-qa.md
@@ -1,0 +1,86 @@
+# Issue #15 統合QA記録
+
+この記録は、`docs/game-rules.md` の初期版CPU戦について、統合自動テストと
+端末・画面QAで実際に確認した範囲を記録する。新しいゲームルールは追加していない。
+
+## 実施環境
+
+- 実施日時: 2026-08-05 14:29–14:35 JST（05:29–05:35 UTC）
+- checkout: `codex/issue-15-integration-qa`, 実施開始時のHEAD `62521a1`
+- host: macOS 26.5.2 / Darwin arm64（`uname -a`: Darwin 25.5.0）
+- Flutter: 3.44.8、Dart 3.12.2（FVM 2.2.6）
+- Xcode: 26.6 (17F113)
+- 端末: iPhone 17 Simulator、iOS 26.5 (23F77)、モデル `iPhone18,3`、UDID
+  `2EBD3334-E7B5-42DC-BFBE-EEF75C95AEF7`
+- スクリーンショット: `xcrun simctl io ... screenshot` が成功し、設定画面の
+  10島マップを1206×2622 pixelで取得。SHA-256
+  `da4017d0b3b0ed62fa45df3beee2e438c5caaf3de6544a6afae393693d0f9040`
+  （`/tmp/conquest-issue-15-board.png`）。一時的なSimulator画面であり、個別の
+  画像ファイルを成果物に含める必要はないためcommitしていない。
+
+## 統合自動テスト
+
+`test/integration_qa_test.dart` は `ProviderContainer`、固定乱数、手動
+`GameLoop` を接続し、実際の `GameController` → `GameRules` → `CpuStrategy` の経路を
+走らせる。
+
+| 確認項目 | 自動テスト | 結果 |
+| --- | --- | --- |
+| 6・8・10・12島の生成、点対称ペア、開始前マップ、3秒カウントダウン | `starts every supported map deterministically through the countdown` | PASS |
+| 固定乱数で同じ試合結果を再現 | `replays the same CPU result with a fixed seed and manual loop` | PASS |
+| プレイヤー勝利（CPU本陣占領） | `completes a scripted player victory on every map size` | PASS |
+| CPU勝利（プレイヤー最後の島を占領） | `replays the same CPU result with a fixed seed and manual loop` | PASS |
+| 同時到着による引き分け、結果後の停止 | `resolves a draw from simultaneous equal arrivals and freezes the loop` | PASS |
+| 自軍増援の上限、中立の同数攻撃、敵島の超過攻撃 | `keeps friendly, neutral, and enemy boundary arrivals independent` | PASS |
+| 一時停止、再開カウントダウン、結果、再戦、provider破棄 | `pauses, resumes, rematches, and disposes without advancing state` | PASS |
+| 多数部隊の同時存在、取りこぼし・上書きなし | `handles many simultaneous troops without dropping or overwriting them` | PASS |
+
+個別ルールの境界値は既存テストでも確認している。`test/game_rules_test.dart` の
+成長境界・容量上限・移動時間・中立/敵の不足/同数/超過・同時到着・最後の島喪失後の
+移動中部隊・引き分け凍結、`test/game_controller_test.dart` の選択/出兵/複数部隊/
+provider破棄、`test/cpu_strategy_test.dart` の防衛・攻撃優先順位、`test/widget_test.dart`
+のSafe Area・縦長制約・意味論・pause/resume/resultを合わせて対象ルールを網羅する。
+
+## 端末・画面QA（実観測）
+
+Flutter debugアプリを `fvm flutter run -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AEF7`
+で起動し、Simulatorのアクセシビリティツリーと画面を確認した。
+
+| QA項目 | 実施結果 | 証拠・制約 |
+| --- | --- | --- |
+| スマートフォン縦向き | PASS | iPhone 17のportrait画面で起動。Safe Area内に本陣と設定パネルを表示。 |
+| 6・8・10・12島の盤面 | PASS | 設定チップを順に選択し、AXで`Island map, N islands`を6/8/10/12すべて確認。 |
+| Safe Areaとタップ領域 | PASS | countdown画面の本陣・中立島がノッチ/下端内側に配置。playing中にプレイヤー本陣をタップできた。 |
+| 島のサイズ・所属・現在値・上限値 | PASS | AXでheadquarters `forces N of 200`、small/medium/largeの所属、耐久値、上限値を確認。 |
+| 選択・解除・無効フィードバック | PARTIAL | playing中に`selected dispatch source`と有効な移動先表示を確認。解除/無効メッセージの自動テストはPASS。 |
+| 両軍の複数移動部隊 | PASS | playing中にAXでCPU moving troopを複数確認。200部隊の統合自動テストもPASS。 |
+| カウントダウン | PASS | AX/画面で`Game start 3`を確認し、完了後にPAUSEと操作可能な島を確認。 |
+| 一時停止 | PASS | PAUSEをタップし、`Game Paused`、`RESUME`、`QUIT MATCH`を確認。 |
+| 再開 | PASS | RESUME後に`Game start 3`を確認し、playingへ復帰。 |
+| 結果画面 | PASS | CPU進行後に`Defeat`、`PLAY AGAIN`、`RETURN TO SETTINGS`を確認。 |
+| 再戦 | PASS | `PLAY AGAIN`後に同じ10島数の新マップとカウントダウンを確認。 |
+| 色以外の陣営識別 | PASS | AXでPlayer/CPU/Neutralのラベル、`P`/`C`/`N`マーク、数値を確認。 |
+| 長時間試合の操作性・描画安定性 | 未手動 | 長時間の実時間試合は実施せず、固定時間の成長境界・CPU進行・多数部隊を自動テストで代替。 |
+| バックグラウンド自動一時停止 | 未手動 | Simulatorでのホーム遷移は今回実施せず。`test/widget_test.dart` の`backgrounding a playing board pauses it automatically`でライフサイクル通知を検証。 |
+| 移動先タップによる実端末出兵 | 未手動 | CPUの再描画でAX element IDが短時間に更新され、今回のComputer Use操作ではdestination dispatchの安定した証跡を取得できなかった。`test/widget_test.dart` と `test/game_controller_test.dart` のタップ自動テストで補完。 |
+
+## `game-rules.md` 対応表
+
+| ルール文書の節 | 対応する自動テスト/端末QA |
+| --- | --- |
+| ゲームの目的、陣営色以外の識別、本陣喪失と全滅、勝利/敗北/引き分け | `game_rules_test.dart` の結果判定・本陣単独喪失・同時全滅、`integration_qa_test.dart` の3結果、端末AXのP/C/Nラベル |
+| ゲーム開始、6/8/10/12島、初期10島、3/2/1/START | `game_rules_test.dart` の構成/マップ、`integration_qa_test.dart` の全島数開始、`widget_test.dart` の設定/カウントダウン、端末QA |
+| 点対称マップ、島サイズ、耐久力、容量、Safe Area、重なりなし | `game_rules_test.dart` の生成/矩形検査、`widget_test.dart` の縦長/resize検査、端末QA |
+| 兵力増加、1秒境界、上限、中立非成長、到着前成長 | `game_rules_test.dart` のgrowth/境界/容量テスト |
+| 島選択、半分切り捨て、選択解除、繰り返し出兵、複数部隊 | `game_controller_test.dart` のselection/dispatch/multiple troops、`widget_test.dart` のsemantics、統合多数部隊 |
+| 移動速度、距離比例、到着時のみ処理 | `game_rules_test.dart` のmovement duration/arrival tests、統合境界到着 |
+| 自軍増援、中立/敵の不足・同数・超過、残存兵力上限、同時到着 | `game_rules_test.dart` のcombat tests、`integration_qa_test.dart` のboundary/simultaneous tests |
+| CPU間隔、1判断1部隊、防衛、攻撃/出兵元優先、到着予測 | `cpu_strategy_test.dart` 全体、`cpu_controller_integration_test.dart`、固定乱数CPU統合 |
+| 表示値、選択枠、移動部隊値、無効フィードバック | `widget_test.dart` のsemantics/feedback/moving-force tests、端末AX観測 |
+| 一時停止、バックグラウンド、再開、途中終了、未保存 | `game_controller_test.dart`、`widget_test.dart` のpause/quit/lifecycle、統合pause/resume/dispose |
+| 結果停止、もう一度、設定へ戻る | `game_controller_test.dart`、`widget_test.dart`、統合result/rematch |
+
+### 対象外
+
+難易度選択、同一端末2人対戦、オンライン対戦、初期版に不要な演出、試合の保存・復元は
+Issue #15および初期ルール文書の対象外であり、実装・QAしていない。

--- a/docs/integration-qa.md
+++ b/docs/integration-qa.md
@@ -5,7 +5,7 @@
 
 ## 実施環境
 
-- 実施日時: 2026-08-05 14:29–15:15 JST（05:29–06:15 UTC）
+- 実施日時: 2026-08-05 14:29–16:18 JST（05:29–07:18 UTC）
 - checkout: `codex/issue-15-integration-qa`, 実施開始時のHEAD `74fdb47`
 - host: macOS 26.5.2 / Darwin arm64（`uname -a`: Darwin 25.5.0）
 - Flutter: 3.44.8、Dart 3.12.2（FVM 2.2.6）
@@ -23,6 +23,14 @@
   wall-clock計測も10分以上をassertした。開始画面のSHA-256は
   `423c0c7d7e75ef9c4e7644f3eb3479b445dc081ef9f620245c454c5397c56059`
   （`/tmp/conquest-issue-15-integration-start.png`）。
+- 修正後の再実行は16:06:32 JSTに開始し、16:17:46 JSTごろにrunnerが完了した
+  （テスト内wall-clock `661s`）。`fullyLive` frame policyでフレーム39,421、
+  FrameTiming 40,420、実端末dispatch 62回、pause/resume 3回、結果→再戦10回、
+  Flutter framework error 0件を記録し、exit 0 / `All tests passed!` を確認した。
+- 同再実行の開始直後に12島すべての島矩形とPAUSE hit regionを比較し、PAUSEと交差する島
+  `0`件、全島で中心/四隅のhit-test候補を確認した。実測PAUSE矩形は
+  `Rect.fromLTRB(294.0, 74.0, 390.0, 122.0)`（SafeArea内の共有契約96×48、padding 12）で、
+  マップ生成は保守的な120×72予約矩形を使う。
 - iOS integration_testの実行時にFlutter 3.44.8が追加する
   `FlutterGeneratedPluginSwiftPackage`のpbxproj/scheme移行は、2回目のiOS simulator
   buildで追加diffが発生しないことを確認したため、テスト依存を再現するin-scopeの
@@ -61,7 +69,7 @@ Flutter debugアプリを `fvm flutter run -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AE
 | --- | --- | --- |
 | スマートフォン縦向き | PASS | iPhone 17のportrait画面で起動。Safe Area内に本陣と設定パネルを表示。 |
 | 6・8・10・12島の盤面 | PASS | 設定チップを順に選択し、AXで`Island map, N islands`を6/8/10/12すべて確認。 |
-| Safe Areaとタップ領域 | PASS | countdown画面の本陣・中立島がノッチ/下端内側に配置。playing中にプレイヤー本陣をタップできた。 |
+| Safe Areaとタップ領域 | PASS | countdown画面の本陣・中立島がノッチ/下端内側に配置。PAUSEのhit regionと島矩形を実測し、12島すべてが交差なし・hit-test可能。マップ生成も共有120×72予約矩形を除外する。 |
 | 島のサイズ・所属・現在値・上限値 | PASS | AXでheadquarters `forces N of 200`、small/medium/largeの所属、耐久値、上限値を確認。 |
 | 選択・解除・無効フィードバック | PARTIAL | playing中に`selected dispatch source`と有効な移動先表示を確認。解除/無効メッセージの自動テストはPASS。 |
 | 両軍の複数移動部隊 | PASS | playing中にAXでCPU moving troopを複数確認。220部隊の統合自動テストもPASS。 |
@@ -71,9 +79,9 @@ Flutter debugアプリを `fvm flutter run -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AE
 | 結果画面 | PASS | CPU進行後に`Defeat`、`PLAY AGAIN`、`RETURN TO SETTINGS`を確認。 |
 | 再戦 | PASS | `PLAY AGAIN`後に同じ10島数の新マップとカウントダウンを確認。 |
 | 色以外の陣営識別 | PASS | AXでPlayer/CPU/Neutralのラベル、`P`/`C`/`N`マーク、数値を確認。 |
-| 長時間試合の操作性・描画安定性 | PASS | iPhone 17 Simulatorで12島をSTARTし、冒頭と10秒間隔の出兵、3回のPAUSE→2秒停止確認→RESUME（約1/5/8分）、結果時の再戦回復分岐を監視。`Future.delayed`で10分以上の実時間を確保し、各観測で`pump`して連続描画を確認。テスト終了はexit 0 / `All tests passed!`、dispatch 2回以上・pause/resume 2回以上・Flutter framework exception 0件をassert。15:14:57 JSTの終盤スクリーンショットでもplaying/PAUSEを確認し、runner teardown後はSimulatorホーム画面へ戻った。 |
+| 長時間試合の操作性・描画安定性 | PASS | iPhone 17 Simulatorで12島をSTARTし、`fullyLive` frame policy、冒頭と10秒間隔の出兵、3回のPAUSE→2秒停止確認→RESUME（約1/5/8分）、結果時の再戦回復分岐を監視。`Future.delayed`で10分以上の実時間を確保し、各観測でフレーム増加をassert。修正後runはwall-clock 661秒、frames 40,421、timings 40,420、dispatch 62回、pause/resume 3回、results/rematches 10/10、Flutter framework exception 0件、exit 0 / `All tests passed!`。初回runの15:14:57 JST終盤スクリーンショットでもplaying/PAUSEを確認し、runner teardown後はSimulatorホーム画面へ戻った。 |
 | バックグラウンド自動一時停止 | 未手動 | Simulatorでのホーム遷移は今回実施せず。`test/widget_test.dart` の`backgrounding a playing board pauses it automatically`でライフサイクル通知を検証。 |
-| 移動先タップによる実端末出兵 | PASS | `integration_test/issue_15_device_qa_test.dart` がiPhone 17上でsource/destinationを実際にtapし、複数dispatchと移動部隊描画をassert。手動AX操作はCPU再描画でIDが更新されたため補完扱い。 |
+| 移動先タップによる実端末出兵 | PASS | `integration_test/issue_15_device_qa_test.dart` がiPhone 17上でsource/destinationを実際にtapし、前後のmoving-force ID・player faction・source/destinationを比較し、生成された`moving-force-<id>` widgetを確認。修正後runでdispatch 62回。手動AX操作はCPU再描画でIDが更新されたため補完扱い。 |
 
 ## `game-rules.md` 対応表
 

--- a/integration_test/issue_15_device_qa_test.dart
+++ b/integration_test/issue_15_device_qa_test.dart
@@ -1,17 +1,42 @@
+import 'dart:ui' show Offset, Rect;
+
 import 'package:conquest/game/game_controller.dart';
 import 'package:conquest/game/game_state.dart';
 import 'package:conquest/main.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
 
   testWidgets(
     'keeps a live iPhone board rendering and responsive for ten minutes',
     (tester) async {
+      var collectFrames = true;
+      var renderedFrameCount = 0;
+      var timedFrameCount = 0;
+      void observePostFrame(Duration _) {
+        renderedFrameCount++;
+        if (collectFrames) {
+          SchedulerBinding.instance.addPostFrameCallback(observePostFrame);
+        }
+      }
+
+      void observeTimings(List<FrameTiming> timings) {
+        timedFrameCount += timings.length;
+      }
+
+      SchedulerBinding.instance.addPostFrameCallback(observePostFrame);
+      SchedulerBinding.instance.addTimingsCallback(observeTimings);
+      addTearDown(() {
+        collectFrames = false;
+        SchedulerBinding.instance.removeTimingsCallback(observeTimings);
+      });
+
       final frameworkErrors = <FlutterErrorDetails>[];
       final previousErrorHandler = FlutterError.onError;
       FlutterError.onError = (details) {
@@ -34,6 +59,11 @@ void main() {
       await Future<void>.delayed(const Duration(seconds: 4));
       await tester.pump();
       expect(find.byKey(const ValueKey('pause-game')), findsOneWidget);
+      expect(
+        renderedFrameCount,
+        greaterThan(10),
+        reason: 'fullyLive must process app-requested frames during gameplay',
+      );
 
       final container = ProviderScope.containerOf(
         tester.element(find.byKey(const ValueKey('island-0'))),
@@ -44,37 +74,127 @@ void main() {
       var resultCount = 0;
       final observedPhases = <GamePhase>{};
 
-      Future<void> dispatchFromCurrentPlayer() async {
+      final pauseRect = tester.getRect(
+        find.byKey(const ValueKey('pause-game')),
+      );
+      var obscuredIslandCount = 0;
+      for (final island in container.read(gameControllerProvider).islands) {
+        final islandFinder = find.byKey(ValueKey('island-button-${island.id}'));
+        final islandRect = tester.getRect(islandFinder);
+        if (islandRect.overlaps(pauseRect)) {
+          obscuredIslandCount++;
+        }
+        expect(
+          islandRect.overlaps(pauseRect),
+          isFalse,
+          reason: 'island ${island.id} must not overlap the pause control',
+        );
+
+        final islandRenderObject = tester.renderObject(islandFinder);
+        final tapCandidates = <Offset>[
+          islandRect.center,
+          islandRect.topLeft + const Offset(2, 2),
+          islandRect.topRight + const Offset(-2, 2),
+          islandRect.bottomLeft + const Offset(2, -2),
+          islandRect.bottomRight + const Offset(-2, -2),
+        ];
+        final hasIslandHit = tapCandidates.any(
+          (point) => tester
+              .hitTestOnBinding(point)
+              .path
+              .any((entry) => entry.target == islandRenderObject),
+        );
+        expect(
+          hasIslandHit,
+          isTrue,
+          reason: 'island ${island.id} must retain a tappable hit area',
+        );
+      }
+      expect(obscuredIslandCount, 0);
+      debugPrint(
+        'Issue #15 device QA geometry: islands='
+        '${container.read(gameControllerProvider).islands.length} '
+        'pauseRect=$pauseRect obscuredIslands=$obscuredIslandCount',
+      );
+
+      bool isCoveredByPause(Finder finder) {
+        final pauseFinder = find.byKey(const ValueKey('pause-game'));
+        if (pauseFinder.evaluate().isEmpty) {
+          return false;
+        }
+        final Rect pauseRect = tester.getRect(pauseFinder);
+        return pauseRect.contains(tester.getCenter(finder));
+      }
+
+      Future<bool> dispatchFromCurrentPlayer() async {
         final state = container.read(gameControllerProvider);
         if (state.phase != GamePhase.playing) {
-          return;
+          return false;
         }
         final source = state.islands.firstWhere(
           (island) => island.faction == Faction.player && island.canDispatch,
           orElse: () => state.islands.first,
         );
         if (source.faction != Faction.player || !source.canDispatch) {
-          return;
+          return false;
         }
-        final destination = state.islands.firstWhere(
+        final sourceFinder = find.byKey(ValueKey('island-button-${source.id}'));
+        if (sourceFinder.evaluate().isEmpty || isCoveredByPause(sourceFinder)) {
+          return false;
+        }
+        final destinations = state.islands.where(
           (island) =>
               island.id != source.id && island.faction != Faction.player,
-          orElse: () =>
-              state.islands.firstWhere((island) => island.id != source.id),
         );
-        final sourceFinder = find.byKey(ValueKey('island-button-${source.id}'));
-        final destinationFinder = find.byKey(
-          ValueKey('island-button-${destination.id}'),
-        );
-        if (sourceFinder.evaluate().isEmpty ||
-            destinationFinder.evaluate().isEmpty) {
-          return;
+        IslandState? destination;
+        Finder? destinationFinder;
+        for (final candidate in destinations) {
+          final finder = find.byKey(ValueKey('island-button-${candidate.id}'));
+          if (finder.evaluate().isNotEmpty && !isCoveredByPause(finder)) {
+            destination = candidate;
+            destinationFinder = finder;
+            break;
+          }
         }
+        if (destination == null || destinationFinder == null) {
+          return false;
+        }
+        final selectedDestination = destination;
+        final selectedDestinationFinder = destinationFinder;
+        final beforeIds = state.movingForces.map((force) => force.id).toSet();
         await tester.tap(sourceFinder);
         await tester.pump();
-        await tester.tap(destinationFinder);
+        expect(
+          container.read(gameControllerProvider).selectedIslandId,
+          source.id,
+          reason: 'source tap must select a live player island',
+        );
+        await tester.tap(selectedDestinationFinder, warnIfMissed: false);
         await tester.pump();
+
+        final afterDispatch = container.read(gameControllerProvider);
+        final newPlayerForces = afterDispatch.movingForces
+            .where(
+              (force) =>
+                  !beforeIds.contains(force.id) &&
+                  force.faction == Faction.player &&
+                  force.sourceIslandId == source.id &&
+                  force.destinationIslandId == selectedDestination.id,
+            )
+            .toList();
+        expect(
+          newPlayerForces,
+          hasLength(1),
+          reason: 'destination tap must append one player moving force',
+        );
+        final dispatchedForce = newPlayerForces.single;
+        expect(
+          find.byKey(ValueKey('moving-force-${dispatchedForce.id}')),
+          findsOneWidget,
+          reason: 'newly dispatched force must be rendered on the device',
+        );
         dispatchCount++;
+        return true;
       }
 
       Future<void> recoverIfResult() async {
@@ -92,15 +212,30 @@ void main() {
       // Two dispatches exercise input and movement before the periodic
       // observation window begins.  Later rounds repeat this opportunistically
       // whenever the current board still has a dispatchable player island.
-      await dispatchFromCurrentPlayer();
+      expect(
+        await dispatchFromCurrentPlayer(),
+        isTrue,
+        reason: 'first real device dispatch must succeed',
+      );
       await Future<void>.delayed(const Duration(seconds: 8));
       await tester.pump();
-      await dispatchFromCurrentPlayer();
+      expect(
+        await dispatchFromCurrentPlayer(),
+        isTrue,
+        reason: 'second real device dispatch must succeed',
+      );
 
       final wallClockStart = DateTime.now();
+      var previousFrameCount = renderedFrameCount;
       for (var interval = 0; interval < 60; interval++) {
         await Future<void>.delayed(const Duration(seconds: 10));
         await tester.pump();
+        expect(
+          renderedFrameCount,
+          greaterThan(previousFrameCount),
+          reason: 'fullyLive must keep producing frames at each observation',
+        );
+        previousFrameCount = renderedFrameCount;
         observedPhases.add(container.read(gameControllerProvider).phase);
 
         if (interval == 5 || interval == 30 || interval == 50) {
@@ -137,6 +272,16 @@ void main() {
       expect(dispatchCount, greaterThanOrEqualTo(2));
       expect(pauseResumeCount, greaterThanOrEqualTo(2));
       expect(observedPhases, contains(GamePhase.playing));
+      expect(renderedFrameCount, greaterThan(100));
+      // FrameTiming is engine-dependent in debug simulator runs; retain its
+      // count as an additional diagnostic when the engine reports it.
+      debugPrint(
+        'Issue #15 device QA: duration=${wallClockDuration.inSeconds}s '
+        'frames=$renderedFrameCount timings=$timedFrameCount '
+        'dispatches=$dispatchCount pauseResume=$pauseResumeCount '
+        'results=$resultCount rematches=$rematchCount '
+        'frameworkErrors=${frameworkErrors.length}',
+      );
       // A result is an expected game outcome, not a framework exception.  If
       // it occurred, the test rematched and continued observing the live app.
       expect(rematchCount, resultCount);

--- a/integration_test/issue_15_device_qa_test.dart
+++ b/integration_test/issue_15_device_qa_test.dart
@@ -1,0 +1,147 @@
+import 'package:conquest/game/game_controller.dart';
+import 'package:conquest/game/game_state.dart';
+import 'package:conquest/main.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'keeps a live iPhone board rendering and responsive for ten minutes',
+    (tester) async {
+      final frameworkErrors = <FlutterErrorDetails>[];
+      final previousErrorHandler = FlutterError.onError;
+      FlutterError.onError = (details) {
+        frameworkErrors.add(details);
+        previousErrorHandler?.call(details);
+      };
+      addTearDown(() => FlutterError.onError = previousErrorHandler);
+
+      await tester.pumpWidget(const ProviderScope(child: MyApp()));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('start-game')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('island-count-12')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('start-game')));
+      await tester.pump();
+
+      // Keep this wall-clock wait real: the production periodic loop, CPU
+      // deadline, rendering, and lifecycle callbacks must run on the device.
+      await Future<void>.delayed(const Duration(seconds: 4));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pause-game')), findsOneWidget);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byKey(const ValueKey('island-0'))),
+      );
+      var dispatchCount = 0;
+      var pauseResumeCount = 0;
+      var rematchCount = 0;
+      var resultCount = 0;
+      final observedPhases = <GamePhase>{};
+
+      Future<void> dispatchFromCurrentPlayer() async {
+        final state = container.read(gameControllerProvider);
+        if (state.phase != GamePhase.playing) {
+          return;
+        }
+        final source = state.islands.firstWhere(
+          (island) => island.faction == Faction.player && island.canDispatch,
+          orElse: () => state.islands.first,
+        );
+        if (source.faction != Faction.player || !source.canDispatch) {
+          return;
+        }
+        final destination = state.islands.firstWhere(
+          (island) =>
+              island.id != source.id && island.faction != Faction.player,
+          orElse: () =>
+              state.islands.firstWhere((island) => island.id != source.id),
+        );
+        final sourceFinder = find.byKey(ValueKey('island-button-${source.id}'));
+        final destinationFinder = find.byKey(
+          ValueKey('island-button-${destination.id}'),
+        );
+        if (sourceFinder.evaluate().isEmpty ||
+            destinationFinder.evaluate().isEmpty) {
+          return;
+        }
+        await tester.tap(sourceFinder);
+        await tester.pump();
+        await tester.tap(destinationFinder);
+        await tester.pump();
+        dispatchCount++;
+      }
+
+      Future<void> recoverIfResult() async {
+        if (find.byKey(const ValueKey('replay-game')).evaluate().isEmpty) {
+          return;
+        }
+        resultCount++;
+        await tester.tap(find.byKey(const ValueKey('replay-game')));
+        await tester.pump();
+        rematchCount++;
+        await Future<void>.delayed(const Duration(seconds: 4));
+        await tester.pump();
+      }
+
+      // Two dispatches exercise input and movement before the periodic
+      // observation window begins.  Later rounds repeat this opportunistically
+      // whenever the current board still has a dispatchable player island.
+      await dispatchFromCurrentPlayer();
+      await Future<void>.delayed(const Duration(seconds: 8));
+      await tester.pump();
+      await dispatchFromCurrentPlayer();
+
+      final wallClockStart = DateTime.now();
+      for (var interval = 0; interval < 60; interval++) {
+        await Future<void>.delayed(const Duration(seconds: 10));
+        await tester.pump();
+        observedPhases.add(container.read(gameControllerProvider).phase);
+
+        if (interval == 5 || interval == 30 || interval == 50) {
+          if (find.byKey(const ValueKey('pause-game')).evaluate().isNotEmpty) {
+            await tester.tap(find.byKey(const ValueKey('pause-game')));
+            await tester.pump();
+            expect(find.text('Game Paused'), findsOneWidget);
+            final pausedElapsed = container
+                .read(gameControllerProvider)
+                .elapsedMs;
+            await Future<void>.delayed(const Duration(seconds: 2));
+            await tester.pump();
+            expect(
+              container.read(gameControllerProvider).elapsedMs,
+              pausedElapsed,
+            );
+            await tester.tap(find.byKey(const ValueKey('resume-game')));
+            await tester.pump();
+            pauseResumeCount++;
+            await Future<void>.delayed(const Duration(seconds: 4));
+            await tester.pump();
+          }
+        }
+
+        await recoverIfResult();
+        await dispatchFromCurrentPlayer();
+      }
+
+      final wallClockDuration = DateTime.now().difference(wallClockStart);
+      expect(
+        wallClockDuration,
+        greaterThanOrEqualTo(const Duration(minutes: 10)),
+      );
+      expect(dispatchCount, greaterThanOrEqualTo(2));
+      expect(pauseResumeCount, greaterThanOrEqualTo(2));
+      expect(observedPhases, contains(GamePhase.playing));
+      // A result is an expected game outcome, not a framework exception.  If
+      // it occurred, the test rematched and continued observing the live app.
+      expect(rematchCount, resultCount);
+      expect(frameworkErrors, isEmpty);
+    },
+    timeout: const Timeout(Duration(minutes: 13)),
+  );
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -44,6 +45,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,6 +63,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -105,6 +109,9 @@
 
 /* Begin PBXNativeTarget section */
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -128,6 +135,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1510;
@@ -473,6 +483,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/lib/game/game_rules.dart
+++ b/lib/game/game_rules.dart
@@ -7,6 +7,17 @@ import 'game_state.dart';
 final class IslandMapViewport {
   const IslandMapViewport({required this.width, required this.height});
 
+  /// Shared geometry for the renderer's top-right pause control.  The map
+  /// reserves the button plus its padding so random islands cannot leave only
+  /// a sliver of a tap target visible underneath it on a phone screen.
+  static const pauseControlPadding = 12.0;
+  static const pauseButtonWidth = 96.0;
+  static const pauseButtonHeight = 48.0;
+  static const topRightControlReservedWidth =
+      pauseButtonWidth + pauseControlPadding * 2;
+  static const topRightControlReservedHeight =
+      pauseButtonHeight + pauseControlPadding * 2;
+
   /// A representative portrait viewport used by the regression tests.
   static const reference = IslandMapViewport(width: 390, height: 844);
 
@@ -16,6 +27,17 @@ final class IslandMapViewport {
 
   final double width;
   final double height;
+
+  IslandMapRect get topRightControlExclusion {
+    final reservedWidth = math.min(width, topRightControlReservedWidth);
+    final reservedHeight = math.min(height, topRightControlReservedHeight);
+    return IslandMapRect(
+      left: width - reservedWidth,
+      top: 0,
+      right: width,
+      bottom: reservedHeight,
+    );
+  }
 
   bool get isValid =>
       width.isFinite && height.isFinite && width > 0 && height > 0;
@@ -139,7 +161,7 @@ final class GameRules {
   static const referenceMapViewport = IslandMapViewport.reference;
 
   /// The default retry budget for a complete map generation attempt.
-  static const defaultMapGenerationAttempts = 64;
+  static const defaultMapGenerationAttempts = 1024;
 
   /// The retry budget for placing one symmetric pair during a map attempt.
   static const defaultPairPlacementAttempts = 128;
@@ -859,7 +881,9 @@ final class GameRules {
     List<IslandState> existing,
     IslandMapViewport viewport,
   ) {
-    if (islandRectanglesOverlap(first, second, viewport)) {
+    if (islandRectanglesOverlap(first, second, viewport) ||
+        _islandOverlapsTopRightControl(first, viewport) ||
+        _islandOverlapsTopRightControl(second, viewport)) {
       return false;
     }
     for (final island in existing) {
@@ -869,6 +893,13 @@ final class GameRules {
       }
     }
     return true;
+  }
+
+  static bool _islandOverlapsTopRightControl(
+    IslandState island,
+    IslandMapViewport viewport,
+  ) {
+    return viewport.rectFor(island).overlaps(viewport.topRightControlExclusion);
   }
 
   static bool islandRectanglesOverlap(

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -174,14 +174,18 @@ class _PauseButton extends StatelessWidget {
     return Align(
       alignment: Alignment.topRight,
       child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Semantics(
-          button: true,
-          label: 'Pause game',
-          child: ElevatedButton(
-            key: const ValueKey('pause-game'),
-            onPressed: onPressed,
-            child: const Text('PAUSE'),
+        padding: const EdgeInsets.all(IslandMapViewport.pauseControlPadding),
+        child: SizedBox(
+          width: IslandMapViewport.pauseButtonWidth,
+          height: IslandMapViewport.pauseButtonHeight,
+          child: Semantics(
+            button: true,
+            label: 'Pause game',
+            child: ElevatedButton(
+              key: const ValueKey('pause-game'),
+              onPressed: onPressed,
+              child: const Text('PAUSE'),
+            ),
           ),
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -259,6 +264,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -291,6 +301,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -411,6 +426,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:
@@ -419,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -576,6 +607,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -656,6 +695,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.15.1
   riverpod_generator: ^4.0.4

--- a/test/game_rules_test.dart
+++ b/test/game_rules_test.dart
@@ -198,12 +198,12 @@ void main() {
     ];
     for (final total in GameConfiguration.allowedIslandCounts) {
       for (var seed = 0; seed < 20; seed++) {
-        final islands = rules.generateIslands(
-          configuration: GameConfiguration(totalIslandCount: total),
-          random: Random(seed),
-        );
-
         for (final viewport in viewports) {
+          final islands = rules.generateIslands(
+            configuration: GameConfiguration(totalIslandCount: total),
+            random: Random(seed),
+            viewport: viewport,
+          );
           for (final island in islands) {
             expect(island.x, inInclusiveRange(-1.0, 1.0));
             expect(island.y, inInclusiveRange(-1.0, 1.0));
@@ -216,6 +216,13 @@ void main() {
               rectangles[index].isWithin(viewport),
               isTrue,
               reason: 'island ${islands[index].id} is outside the safe area',
+            );
+            expect(
+              rectangles[index].overlaps(viewport.topRightControlExclusion),
+              isFalse,
+              reason:
+                  'island ${islands[index].id} overlaps the pause control '
+                  'exclusion area',
             );
           }
           for (
@@ -237,6 +244,46 @@ void main() {
               );
             }
           }
+        }
+      }
+    }
+  });
+
+  test('map generation reserves the renderer pause control envelope', () {
+    const viewport = IslandMapViewport(width: 402, height: 874);
+    final exclusion = viewport.topRightControlExclusion;
+    expect(exclusion.left, 282);
+    expect(exclusion.top, 0);
+    expect(exclusion.right, 402);
+    expect(exclusion.bottom, 72);
+
+    const candidate = IslandState(
+      id: 2,
+      position: IslandPosition(x: 0.7, y: -0.9),
+      faction: Faction.neutral,
+      size: IslandSize.small,
+      durability: 10,
+      capacity: 50,
+    );
+    expect(viewport.rectFor(candidate).overlaps(exclusion), isTrue);
+
+    for (final total in GameConfiguration.allowedIslandCounts) {
+      for (var seed = 0; seed < 100; seed++) {
+        final islands = rules.generateIslands(
+          configuration: GameConfiguration(totalIslandCount: total),
+          random: Random(seed),
+          viewport: viewport,
+        );
+        for (final island in islands) {
+          expect(
+            viewport.rectFor(island).overlaps(exclusion),
+            isFalse,
+            reason: 'seed $seed island ${island.id} overlaps pause control',
+          );
+        }
+        for (var index = 2; index < islands.length; index += 2) {
+          expect(islands[index + 1].x, closeTo(-islands[index].x, 1e-12));
+          expect(islands[index + 1].y, closeTo(-islands[index].y, 1e-12));
         }
       }
     }

--- a/test/integration_qa_test.dart
+++ b/test/integration_qa_test.dart
@@ -46,6 +46,19 @@ final class _QaManualLoop implements GameLoop {
   }
 }
 
+/// Keeps the CPU's production judgment interval at its minimum for scenarios
+/// that need to observe one complete controller-to-arrival path.
+final class _QaZeroRandom implements Random {
+  @override
+  bool nextBool() => false;
+
+  @override
+  double nextDouble() => 0;
+
+  @override
+  int nextInt(int max) => 0;
+}
+
 ProviderContainer _createContainer({
   required _QaManualLoop loop,
   required int islandCount,
@@ -242,6 +255,111 @@ void main() {
       expect(first, second, reason: 'islands=$islandCount');
       expect(first.resultType, GameResultType.defeat);
       expect(first.winner, Faction.cpu);
+    }
+  });
+
+  test('dispatches CPU defense before a threatened island can be occupied', () {
+    final loop = _QaManualLoop();
+    final container = _createContainer(
+      loop: loop,
+      islandCount: 6,
+      seed: 5100,
+      cpuStrategy: CpuStrategy(
+        random: _QaZeroRandom(),
+        viewport: GameRules.defaultMapViewport,
+      ),
+    );
+    try {
+      final controller = container.read(gameControllerProvider.notifier);
+      final started = _startMatch(container, loop);
+      final playerHeadquarters = started.islands[0].copyWith(
+        position: const IslandPosition(x: 0.8, y: 0.8),
+        currentForces: 100,
+      );
+      final cpuHeadquarters = started.islands[1].copyWith(
+        position: const IslandPosition(x: -0.5, y: -0.1),
+        currentForces: 20,
+      );
+      final cpuTarget = started.islands[2].copyWith(
+        position: const IslandPosition(x: -0.2, y: -0.1),
+        faction: Faction.cpu,
+        currentForces: 5,
+        durability: 0,
+        size: IslandSize.medium,
+        capacity: 100,
+      );
+      final playerReserve = started.islands[3].copyWith(
+        faction: Faction.player,
+        currentForces: 1,
+      );
+      final playerThreat = MovingForce(
+        id: 710,
+        faction: Faction.player,
+        sourceIslandId: playerHeadquarters.id,
+        destinationIslandId: cpuTarget.id,
+        strength: 10,
+        departureTimeMs: 0,
+        arrivalTimeMs: 2800,
+        durationMs: 2800,
+      );
+      controller.state = started.copyWith(
+        islands: [
+          playerHeadquarters,
+          cpuHeadquarters,
+          cpuTarget,
+          playerReserve,
+          ...started.islands.skip(4),
+        ],
+        movingForces: [playerThreat],
+      );
+
+      loop.tickMany(29);
+      expect(container.read(gameControllerProvider).elapsedMs, 1450);
+      expect(
+        container
+            .read(gameControllerProvider)
+            .movingForces
+            .where((force) => force.faction == Faction.cpu),
+        isEmpty,
+      );
+
+      loop.tick();
+      final defenseDispatched = container.read(gameControllerProvider);
+      final defenseForces = defenseDispatched.movingForces
+          .where((force) => force.faction == Faction.cpu)
+          .toList();
+      expect(defenseForces, hasLength(1));
+      final defense = defenseForces.single;
+      expect(defense.sourceIslandId, cpuHeadquarters.id);
+      expect(defense.destinationIslandId, cpuTarget.id);
+      expect(defense.strength, 10);
+      expect(
+        defense.arrivalTimeMs,
+        lessThanOrEqualTo(playerThreat.arrivalTimeMs),
+      );
+      expect(
+        defenseDispatched.islands
+            .firstWhere((island) => island.id == cpuHeadquarters.id)
+            .currentForces,
+        11,
+      );
+
+      while (container.read(gameControllerProvider).elapsedMs < 2800) {
+        loop.tick();
+      }
+      final defended = container.read(gameControllerProvider);
+      final defendedTarget = defended.islands.firstWhere(
+        (island) => island.id == cpuTarget.id,
+      );
+      expect(defendedTarget.faction, Faction.cpu);
+      expect(defendedTarget.currentForces, greaterThan(0));
+      expect(
+        defended.movingForces.any((force) => force.id == playerThreat.id),
+        isFalse,
+      );
+      expect(defended.phase, GamePhase.playing);
+    } finally {
+      container.dispose();
     }
   });
 
@@ -483,54 +601,177 @@ void main() {
   });
 
   test(
-    'handles many simultaneous troops without dropping or overwriting them',
+    'processes asymmetric troops across targets and arrival times exactly',
     () {
       final loop = _QaManualLoop();
       final container = _createContainer(loop: loop, islandCount: 6, seed: 222);
       try {
         final controller = container.read(gameControllerProvider.notifier);
         final started = _startMatch(container, loop);
-        final source = started.islands[0];
-        final target = started.islands[2].copyWith(
+        final playerSource = started.islands[0].copyWith(currentForces: 100);
+        final cpuSource = started.islands[1].copyWith(currentForces: 100);
+        final friendly = started.islands[2].copyWith(
           faction: Faction.player,
-          currentForces: 0,
+          currentForces: 40,
           durability: 0,
-          size: IslandSize.headquarters,
-          capacity: 200,
+          size: IslandSize.small,
+          capacity: 100,
         );
-        final troops = [
-          for (var id = 0; id < 200; id++)
+        final neutral = started.islands[3].copyWith(
+          faction: Faction.neutral,
+          currentForces: 0,
+          durability: 10,
+          size: IslandSize.medium,
+          capacity: 100,
+        );
+        final enemyFirst = started.islands[4].copyWith(
+          faction: Faction.cpu,
+          currentForces: 10,
+          durability: 0,
+          size: IslandSize.medium,
+          capacity: 100,
+        );
+        final enemySecond = started.islands[5].copyWith(
+          faction: Faction.cpu,
+          currentForces: 20,
+          durability: 0,
+          size: IslandSize.medium,
+          capacity: 100,
+        );
+        final troops = <MovingForce>[
+          for (var id = 100; id < 200; id++)
             MovingForce(
               id: id,
-              faction: id.isEven ? Faction.player : Faction.cpu,
-              sourceIslandId: source.id,
-              destinationIslandId: target.id,
-              strength: 1,
+              faction: Faction.player,
+              sourceIslandId: playerSource.id,
+              destinationIslandId: friendly.id,
+              strength: id.isEven ? 1 : 2,
               arrivalTimeMs: 0,
+              durationMs: 1,
+            ),
+          for (var id = 200; id < 240; id++)
+            MovingForce(
+              id: id,
+              faction: Faction.player,
+              sourceIslandId: playerSource.id,
+              destinationIslandId: neutral.id,
+              strength: 1,
+              arrivalTimeMs: 50,
+              durationMs: 1,
+            ),
+          for (var id = 240; id < 255; id++)
+            MovingForce(
+              id: id,
+              faction: Faction.cpu,
+              sourceIslandId: cpuSource.id,
+              destinationIslandId: neutral.id,
+              strength: (id - 240).isEven ? 1 : 2,
+              arrivalTimeMs: 100,
+              durationMs: 1,
+            ),
+          for (var id = 300; id < 325; id++)
+            MovingForce(
+              id: id,
+              faction: Faction.player,
+              sourceIslandId: playerSource.id,
+              destinationIslandId: enemyFirst.id,
+              strength: (id - 300).isEven ? 1 : 2,
+              arrivalTimeMs: 100,
+              durationMs: 1,
+            ),
+          for (var id = 400; id < 410; id++)
+            MovingForce(
+              id: id,
+              faction: Faction.player,
+              sourceIslandId: playerSource.id,
+              destinationIslandId: enemySecond.id,
+              strength: 1,
+              arrivalTimeMs: 50,
+              durationMs: 1,
+            ),
+          for (var id = 410; id < 440; id++)
+            MovingForce(
+              id: id,
+              faction: Faction.player,
+              sourceIslandId: playerSource.id,
+              destinationIslandId: enemySecond.id,
+              strength: (id - 410).isEven ? 1 : 2,
+              arrivalTimeMs: 150,
               durationMs: 1,
             ),
         ];
         controller.state = started.copyWith(
           islands: [
-            source,
-            started.islands[1],
-            target,
-            ...started.islands.skip(3),
+            playerSource,
+            cpuSource,
+            friendly,
+            neutral,
+            enemyFirst,
+            enemySecond,
           ],
           movingForces: troops,
         );
 
         loop.tick();
-
-        final next = container.read(gameControllerProvider);
-        expect(next.movingForces, isEmpty);
-        expect(next.islands, hasLength(6));
+        var next = container.read(gameControllerProvider);
+        expect(next.elapsedMs, 50);
+        expect(next.movingForces, hasLength(70));
         expect(
           next.islands
-              .firstWhere((island) => island.id == target.id)
+              .firstWhere((island) => island.id == friendly.id)
               .currentForces,
+          100,
+        );
+        expect(
+          next.islands
+              .firstWhere((island) => island.id == enemySecond.id)
+              .currentForces,
+          10,
+        );
+        final neutralAfterPlayer = next.islands.firstWhere(
+          (island) => island.id == neutral.id,
+        );
+        expect(neutralAfterPlayer.faction, Faction.player);
+        expect(neutralAfterPlayer.currentForces, 30);
+
+        loop.tick();
+        next = container.read(gameControllerProvider);
+        expect(next.elapsedMs, 100);
+        expect(next.movingForces, hasLength(30));
+        expect(
+          next.islands
+              .firstWhere((island) => island.id == neutral.id)
+              .durability,
           0,
         );
+        final capturedNeutral = next.islands.firstWhere(
+          (island) => island.id == neutral.id,
+        );
+        expect(capturedNeutral.faction, Faction.player);
+        expect(capturedNeutral.currentForces, 8);
+        final capturedFirst = next.islands.firstWhere(
+          (island) => island.id == enemyFirst.id,
+        );
+        expect(capturedFirst.faction, Faction.player);
+        expect(capturedFirst.currentForces, 27);
+
+        loop.tick();
+        next = container.read(gameControllerProvider);
+        expect(next.elapsedMs, 150);
+        expect(next.movingForces, isEmpty);
+        expect(
+          next.islands
+              .firstWhere((island) => island.id == enemySecond.id)
+              .faction,
+          Faction.player,
+        );
+        expect(
+          next.islands
+              .firstWhere((island) => island.id == enemySecond.id)
+              .currentForces,
+          35,
+        );
+        expect(next.islands, hasLength(6));
         expect(next.phase, GamePhase.playing);
       } finally {
         container.dispose();

--- a/test/integration_qa_test.dart
+++ b/test/integration_qa_test.dart
@@ -1,0 +1,540 @@
+import 'dart:math';
+
+import 'package:conquest/game/cpu_strategy.dart';
+import 'package:conquest/game/game_controller.dart';
+import 'package:conquest/game/game_loop.dart';
+import 'package:conquest/game/game_rules.dart';
+import 'package:conquest/game/game_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A deterministic replacement for the production periodic loop.
+///
+/// Every callback advances one 50 ms engine step when the system clock is
+/// used.  This keeps the controller, CPU, and rules connected in these tests
+/// without waiting for wall-clock timers.
+final class _QaManualLoop implements GameLoop {
+  void Function()? _onTick;
+
+  int startCount = 0;
+  int stopCount = 0;
+
+  @override
+  bool get isRunning => _onTick != null;
+
+  @override
+  void start(void Function() onTick) {
+    if (isRunning) {
+      return;
+    }
+    startCount++;
+    _onTick = onTick;
+  }
+
+  @override
+  void stop() {
+    stopCount++;
+    _onTick = null;
+  }
+
+  void tick() => _onTick?.call();
+
+  void tickMany(int count) {
+    for (var index = 0; index < count; index++) {
+      tick();
+    }
+  }
+}
+
+ProviderContainer _createContainer({
+  required _QaManualLoop loop,
+  required int islandCount,
+  required int seed,
+  CpuStrategy? cpuStrategy,
+}) {
+  return ProviderContainer(
+    overrides: [
+      gameConfigurationProvider.overrideWithValue(
+        GameConfiguration(totalIslandCount: islandCount),
+      ),
+      gameLoopProvider.overrideWithValue(loop),
+      randomProvider.overrideWithValue(Random(seed)),
+      if (cpuStrategy != null)
+        cpuStrategyProvider.overrideWithValue(cpuStrategy)
+      else
+        cpuStrategyProvider.overrideWithValue(
+          CpuStrategy.noop(viewport: GameRules.defaultMapViewport),
+        ),
+    ],
+  );
+}
+
+GameState _startMatch(ProviderContainer container, _QaManualLoop loop) {
+  final controller = container.read(gameControllerProvider.notifier);
+  controller.startGame();
+  expect(
+    container.read(gameControllerProvider).phase,
+    GamePhase.startCountdown,
+  );
+  expect(container.read(gameControllerProvider).elapsedMs, 0);
+
+  loop.tickMany(59);
+  final beforeStart = container.read(gameControllerProvider);
+  expect(beforeStart.phase, GamePhase.startCountdown);
+  expect(beforeStart.countdownRemainingMs, 50);
+  expect(beforeStart.elapsedMs, 0);
+
+  loop.tick();
+  final started = container.read(gameControllerProvider);
+  expect(started.phase, GamePhase.playing);
+  expect(started.countdownRemainingMs, 0);
+  expect(started.elapsedMs, 0);
+  return started;
+}
+
+final class _MatchTrace {
+  const _MatchTrace({
+    required this.resultType,
+    required this.winner,
+    required this.elapsedMs,
+    required this.ticks,
+  });
+
+  final GameResultType resultType;
+  final Faction? winner;
+  final int elapsedMs;
+  final int ticks;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _MatchTrace &&
+        other.resultType == resultType &&
+        other.winner == winner &&
+        other.elapsedMs == elapsedMs &&
+        other.ticks == ticks;
+  }
+
+  @override
+  int get hashCode => Object.hash(resultType, winner, elapsedMs, ticks);
+}
+
+_MatchTrace _runCpuVictory({required int islandCount, required int seed}) {
+  final loop = _QaManualLoop();
+  final container = _createContainer(
+    loop: loop,
+    islandCount: islandCount,
+    seed: seed,
+    cpuStrategy: CpuStrategy(
+      random: Random(seed),
+      viewport: GameRules.defaultMapViewport,
+    ),
+  );
+
+  try {
+    final controller = container.read(gameControllerProvider.notifier);
+    final started = _startMatch(container, loop);
+
+    // Keep the generated map and its viewport geometry, but reduce the
+    // scripted player to one vulnerable headquarters.  The CPU still uses
+    // the production strategy and dispatch/movement path, making the result
+    // deterministic without relying on a long wall-clock match.
+    controller.state = started.copyWith(
+      islands: [
+        for (final island in started.islands)
+          island.id == 0
+              ? island.copyWith(
+                  faction: Faction.player,
+                  currentForces: 1,
+                  durability: 0,
+                )
+              : island.copyWith(
+                  faction: Faction.cpu,
+                  currentForces: island.id == 1 ? 100 : 1,
+                  durability: 0,
+                ),
+      ],
+    );
+
+    var ticks = 0;
+    while (container.read(gameControllerProvider).phase != GamePhase.result &&
+        ticks < 300) {
+      loop.tick();
+      ticks++;
+    }
+
+    final result = container.read(gameControllerProvider);
+    expect(result.phase, GamePhase.result);
+    expect(result.result, isNotNull);
+    return _MatchTrace(
+      resultType: result.result!.type,
+      winner: result.result!.winner,
+      elapsedMs: result.result!.elapsedMs,
+      ticks: ticks,
+    );
+  } finally {
+    container.dispose();
+  }
+}
+
+void _assertIslandCountAndMap(GameState state, int islandCount) {
+  expect(state.configuration.totalIslandCount, islandCount);
+  expect(state.islands, hasLength(islandCount));
+  expect(state.islands[0].faction, Faction.player);
+  expect(state.islands[1].faction, Faction.cpu);
+  expect(state.islands[0].currentForces, 100);
+  expect(state.islands[1].currentForces, 100);
+  for (var index = 2; index < state.islands.length; index += 2) {
+    final first = state.islands[index];
+    final second = state.islands[index + 1];
+    expect(first.faction, Faction.neutral);
+    expect(second.faction, Faction.neutral);
+    expect(second.size, first.size);
+    expect(second.position.x, closeTo(-first.position.x, 1e-12));
+    expect(second.position.y, closeTo(-first.position.y, 1e-12));
+    expect(second.durability, first.durability);
+  }
+}
+
+void main() {
+  test(
+    'starts every supported map deterministically through the countdown',
+    () {
+      for (final islandCount in GameConfiguration.allowedIslandCounts) {
+        final firstLoop = _QaManualLoop();
+        final secondLoop = _QaManualLoop();
+        final first = _createContainer(
+          loop: firstLoop,
+          islandCount: islandCount,
+          seed: 1500 + islandCount,
+        );
+        final second = _createContainer(
+          loop: secondLoop,
+          islandCount: islandCount,
+          seed: 1500 + islandCount,
+        );
+
+        try {
+          final firstInitial = first.read(gameControllerProvider);
+          final secondInitial = second.read(gameControllerProvider);
+          expect(firstInitial, secondInitial, reason: 'islands=$islandCount');
+          _assertIslandCountAndMap(firstInitial, islandCount);
+
+          final firstStarted = _startMatch(first, firstLoop);
+          final secondStarted = _startMatch(second, secondLoop);
+          expect(firstStarted, secondStarted, reason: 'islands=$islandCount');
+
+          firstLoop.tick();
+          expect(first.read(gameControllerProvider).elapsedMs, 50);
+          expect(first.read(gameControllerProvider).movingForces, isEmpty);
+        } finally {
+          first.dispose();
+          second.dispose();
+        }
+      }
+    },
+  );
+
+  test('replays the same CPU result with a fixed seed and manual loop', () {
+    for (final islandCount in GameConfiguration.allowedIslandCounts) {
+      final first = _runCpuVictory(islandCount: islandCount, seed: 9000);
+      final second = _runCpuVictory(islandCount: islandCount, seed: 9000);
+
+      expect(first, second, reason: 'islands=$islandCount');
+      expect(first.resultType, GameResultType.defeat);
+      expect(first.winner, Faction.cpu);
+    }
+  });
+
+  test('completes a scripted player victory on every map size', () {
+    for (final islandCount in GameConfiguration.allowedIslandCounts) {
+      final loop = _QaManualLoop();
+      final container = _createContainer(
+        loop: loop,
+        islandCount: islandCount,
+        seed: 7000 + islandCount,
+      );
+      try {
+        final controller = container.read(gameControllerProvider.notifier);
+        final started = _startMatch(container, loop);
+        controller.state = started.copyWith(
+          islands: [
+            for (final island in started.islands)
+              island.id == 1
+                  ? island.copyWith(
+                      currentForces: 10,
+                      faction: Faction.cpu,
+                      durability: 0,
+                    )
+                  : island,
+          ],
+        );
+
+        controller.tapBase(0);
+        controller.tapBase(1);
+        expect(
+          container.read(gameControllerProvider).movingForces,
+          hasLength(1),
+        );
+        loop.tickMany(100);
+
+        final result = container.read(gameControllerProvider);
+        expect(result.phase, GamePhase.result);
+        expect(result.result?.type, GameResultType.victory);
+        expect(result.result?.winner, Faction.player);
+        expect(loop.isRunning, isFalse);
+      } finally {
+        container.dispose();
+      }
+    }
+  });
+
+  test(
+    'resolves a draw from simultaneous equal arrivals and freezes the loop',
+    () {
+      final loop = _QaManualLoop();
+      final container = _createContainer(loop: loop, islandCount: 10, seed: 42);
+      try {
+        final controller = container.read(gameControllerProvider.notifier);
+        final started = _startMatch(container, loop);
+        final target = started.islands.firstWhere((island) => island.id == 2);
+        controller.state = started.copyWith(
+          islands: [
+            for (final island in started.islands)
+              island.copyWith(faction: Faction.neutral, currentForces: 0),
+          ],
+          movingForces: [
+            MovingForce(
+              id: 101,
+              faction: Faction.player,
+              sourceIslandId: 0,
+              destinationIslandId: target.id,
+              strength: target.durability,
+              arrivalTimeMs: 0,
+              durationMs: 1,
+            ),
+            MovingForce(
+              id: 102,
+              faction: Faction.cpu,
+              sourceIslandId: 1,
+              destinationIslandId: target.id,
+              strength: target.durability,
+              arrivalTimeMs: 0,
+              durationMs: 1,
+            ),
+          ],
+        );
+
+        loop.tick();
+
+        final result = container.read(gameControllerProvider);
+        expect(result.phase, GamePhase.result);
+        expect(result.result?.type, GameResultType.draw);
+        expect(result.movingForces, isEmpty);
+        expect(loop.isRunning, isFalse);
+        final frozen = result;
+        loop.tickMany(100);
+        expect(container.read(gameControllerProvider), same(frozen));
+      } finally {
+        container.dispose();
+      }
+    },
+  );
+
+  test('keeps friendly, neutral, and enemy boundary arrivals independent', () {
+    final loop = _QaManualLoop();
+    final container = _createContainer(loop: loop, islandCount: 6, seed: 81);
+    try {
+      final controller = container.read(gameControllerProvider.notifier);
+      final started = _startMatch(container, loop);
+      final source = started.islands[0];
+      final friendly = started.islands[2].copyWith(
+        faction: Faction.player,
+        currentForces: 49,
+        durability: 0,
+        size: IslandSize.small,
+        capacity: 50,
+      );
+      final neutral = started.islands[3].copyWith(
+        faction: Faction.neutral,
+        currentForces: 0,
+        durability: 30,
+        size: IslandSize.medium,
+        capacity: 100,
+      );
+      final enemy = started.islands[4].copyWith(
+        faction: Faction.cpu,
+        currentForces: 10,
+        durability: 0,
+        size: IslandSize.medium,
+        capacity: 100,
+      );
+      controller.state = started.copyWith(
+        islands: [
+          source,
+          started.islands[1],
+          friendly,
+          neutral,
+          enemy,
+          started.islands[5],
+        ],
+        movingForces: [
+          MovingForce(
+            id: 1,
+            faction: Faction.player,
+            sourceIslandId: source.id,
+            destinationIslandId: friendly.id,
+            strength: 20,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+          MovingForce(
+            id: 2,
+            faction: Faction.player,
+            sourceIslandId: source.id,
+            destinationIslandId: neutral.id,
+            strength: 30,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+          MovingForce(
+            id: 3,
+            faction: Faction.player,
+            sourceIslandId: source.id,
+            destinationIslandId: enemy.id,
+            strength: 11,
+            arrivalTimeMs: 0,
+            durationMs: 1,
+          ),
+        ],
+      );
+
+      loop.tick();
+
+      final next = container.read(gameControllerProvider);
+      expect(next.movingForces, isEmpty);
+      expect(
+        next.islands
+            .firstWhere((island) => island.id == friendly.id)
+            .currentForces,
+        50,
+      );
+      final damagedNeutral = next.islands.firstWhere(
+        (island) => island.id == neutral.id,
+      );
+      expect(damagedNeutral.faction, Faction.neutral);
+      expect(damagedNeutral.durability, 0);
+      final capturedEnemy = next.islands.firstWhere(
+        (island) => island.id == enemy.id,
+      );
+      expect(capturedEnemy.faction, Faction.player);
+      expect(capturedEnemy.currentForces, 1);
+      expect(next.phase, GamePhase.playing);
+    } finally {
+      container.dispose();
+    }
+  });
+
+  test('pauses, resumes, rematches, and disposes without advancing state', () {
+    final loop = _QaManualLoop();
+    final container = _createContainer(loop: loop, islandCount: 8, seed: 123);
+    final controller = container.read(gameControllerProvider.notifier);
+    final started = _startMatch(container, loop);
+
+    loop.tickMany(10);
+    controller.pauseGame();
+    final paused = container.read(gameControllerProvider);
+    expect(paused.phase, GamePhase.paused);
+    expect(loop.isRunning, isFalse);
+    loop.tickMany(100);
+    expect(container.read(gameControllerProvider), same(paused));
+
+    controller.resumeGame();
+    expect(
+      container.read(gameControllerProvider).phase,
+      GamePhase.resumeCountdown,
+    );
+    expect(container.read(gameControllerProvider).elapsedMs, paused.elapsedMs);
+    loop.tickMany(60);
+    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
+    expect(container.read(gameControllerProvider).elapsedMs, paused.elapsedMs);
+
+    controller.finish(const GameResult.victory(elapsedMs: 500));
+    final result = container.read(gameControllerProvider);
+    expect(result.phase, GamePhase.result);
+    expect(loop.isRunning, isFalse);
+    final beforeReplayMap = result.islands;
+    controller.replayGame();
+    final replay = container.read(gameControllerProvider);
+    expect(replay.phase, GamePhase.startCountdown);
+    expect(
+      replay.configuration.totalIslandCount,
+      started.configuration.totalIslandCount,
+    );
+    expect(replay.islands, isNot(beforeReplayMap));
+    loop.tickMany(60);
+    expect(container.read(gameControllerProvider).phase, GamePhase.playing);
+
+    // A result or configuration transition is the only place where a match
+    // is intentionally reset.  Disposal must stop the active loop as well.
+    controller.finish(const GameResult.victory(elapsedMs: 600));
+    expect(loop.isRunning, isFalse);
+    container.dispose();
+    expect(loop.stopCount, greaterThanOrEqualTo(1));
+  });
+
+  test(
+    'handles many simultaneous troops without dropping or overwriting them',
+    () {
+      final loop = _QaManualLoop();
+      final container = _createContainer(loop: loop, islandCount: 6, seed: 222);
+      try {
+        final controller = container.read(gameControllerProvider.notifier);
+        final started = _startMatch(container, loop);
+        final source = started.islands[0];
+        final target = started.islands[2].copyWith(
+          faction: Faction.player,
+          currentForces: 0,
+          durability: 0,
+          size: IslandSize.headquarters,
+          capacity: 200,
+        );
+        final troops = [
+          for (var id = 0; id < 200; id++)
+            MovingForce(
+              id: id,
+              faction: id.isEven ? Faction.player : Faction.cpu,
+              sourceIslandId: source.id,
+              destinationIslandId: target.id,
+              strength: 1,
+              arrivalTimeMs: 0,
+              durationMs: 1,
+            ),
+        ];
+        controller.state = started.copyWith(
+          islands: [
+            source,
+            started.islands[1],
+            target,
+            ...started.islands.skip(3),
+          ],
+          movingForces: troops,
+        );
+
+        loop.tick();
+
+        final next = container.read(gameControllerProvider);
+        expect(next.movingForces, isEmpty);
+        expect(next.islands, hasLength(6));
+        expect(
+          next.islands
+              .firstWhere((island) => island.id == target.id)
+              .currentForces,
+          0,
+        );
+        expect(next.phase, GamePhase.playing);
+      } finally {
+        container.dispose();
+      }
+    },
+  );
+}


### PR DESCRIPTION
## 概要

初期版CPU戦のルールを開始から結果・再戦まで統合検証し、iPhone 17 Simulatorで長時間の端末QAを完了しました。固定乱数・手動GameLoopの統合テストと実端末integration testを追加し、QA中に見つかったPAUSEボタンと島のタップ領域の重なりも解消しています。

## 背景・目的

Issue #7〜#14で分割実装したゲームエンジン、CPU、盤面、操作、ライフサイクルが、`docs/game-rules.md` の初期版ルールとして一貫して動作することを、自動テスト・対象ビルド・Simulator実測で確認するためです。

## 対応内容

- 6・8・10・12島の開始、固定条件の再現、勝利・敗北・引き分けを結ぶ統合テストを追加
- 増援・中立/敵境界、同時到着、CPU防衛、pause/resume/result/rematch/provider破棄、220部隊の時差到着を検証
- iPhone 17 Simulator上でfully-live描画を11分14秒継続し、実タップ出兵、pause/resume、結果・再戦、framework exceptionを検証
- `docs/integration-qa.md` にゲームルールと自動/端末QAの対応、環境、実測値、制約を記録
- PAUSE操作領域をrendererとmap生成の共有契約にし、島のタップ領域との重なりを防止
- Flutter `integration_test` とiOS Simulator実行に必要な標準SPM設定を追加

## 主な設計判断

- 固定乱数と手動GameLoopでController・GameRules・CpuStrategyの実経路を再現可能に検証します。
- 長時間QAは`fullyLive` frame policyを使い、実時間、frame/timing、状態差分、移動部隊widget、framework errorを端末上で検証します。
- PAUSE領域は96×48のボタンと12px paddingを共有定数化し、map側は保守的な120×72領域との交差を排除します。点対称ペアは維持します。

## 受け入れ条件との対応

- [x] `docs/game-rules.md` の各ルールを自動テストまたは端末QAへ対応付け
- [x] 6・8・10・12島で開始から結果までの進行を検証
- [x] 固定乱数・手動GameLoopで同じ結果を再現
- [x] プレイヤー勝利、CPU勝利、引き分けを自動検証
- [x] 成長/到着順、境界攻撃、同時到着、多数部隊を検証
- [x] pause/result/provider破棄後に状態が進行しないことを検証
- [x] CPUの攻撃・防衛と複数部隊を統合経路で検証
- [x] 縦向きSimulatorで主要画面、Safe Area、全島hit area、色以外の陣営識別を確認
- [x] format、analyze、全tests、Android/iOS/Web build、diff checkが成功
- [x] 実行環境と検証結果を`docs/integration-qa.md`へ記録

## 検証

- `fvm dart format --output=none --set-exit-if-changed lib test integration_test`: 成功
- `fvm flutter analyze`: 成功（No issues found）
- `fvm flutter test`: 成功（105 tests）
- `fvm flutter test test/integration_qa_test.dart`: 成功（8 tests）
- `fvm flutter test integration_test/issue_15_device_qa_test.dart -d 2EBD3334-E7B5-42DC-BFBE-EEF75C95AEF7`: 成功（11分14秒、40,421 frames、62 dispatches、0 framework errors）
- `fvm flutter build apk --debug`: 成功
- `fvm flutter build ios --simulator --debug --no-codesign`: 成功（連続2回、追加diffなし）
- `fvm flutter build web --release`: 成功
- `git diff --check origin/main...HEAD`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `79288bd1c3faac5ce1e8995509c5003a62fb1c9b`）
- GitHub Codex review（1回のみ）: 指摘なし（review HEAD: `79288bd1c3faac5ce1e8995509c5003a62fb1c9b`）
- Required checks: 対象なし（check runs / commit statuses / Actions runs なし、main branch protection / rulesets なし）

## 残存リスク

実機iPhone/Android端末ではなく、iPhone 17 Simulatorで端末QAを実施しています。Androidはdebug buildまで確認済みです。

Closes #15