### PR TITLE
TestFlight配布とApp Store審査提出workflowを追加する

### DIFF
--- a/.github/workflows/build-ios-app-store.yml
+++ b/.github/workflows/build-ios-app-store.yml
@@ -256,6 +256,21 @@ jobs:
           gem install cocoapods --version 1.16.2 --no-document
           fvm flutter pub get
 
+      - name: Declare App Store export compliance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import plistlib
+
+          path = "ios/Runner/Info.plist"
+          with open(path, "rb") as file:
+              info = plistlib.load(file)
+          info["ITSAppUsesNonExemptEncryption"] = False
+          with open(path, "wb") as file:
+              plistlib.dump(info, file, sort_keys=False)
+          PY
+
       - name: Install signing materials
         id: signing
         shell: bash

--- a/.github/workflows/build-ios-app-store.yml
+++ b/.github/workflows/build-ios-app-store.yml
@@ -1,0 +1,540 @@
+name: Reusable iOS App Store Build
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        required: true
+        type: string
+      distribute_internal:
+        required: true
+        type: boolean
+      submission_source:
+        required: true
+        type: string
+      caller_workflow_name:
+        required: true
+        type: string
+      caller_workflow_path:
+        required: true
+        type: string
+    outputs:
+      app_version:
+        value: ${{ jobs.build.outputs.app_version }}
+      build_number:
+        value: ${{ jobs.build.outputs.build_number }}
+      commit_sha:
+        value: ${{ jobs.build.outputs.commit_sha }}
+      build_id:
+        value: ${{ jobs.build.outputs.build_id }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-store-ios-build
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate target and run Flutter checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    outputs:
+      commit_sha: ${{ steps.target.outputs.sha }}
+      app_version: ${{ steps.version.outputs.app_version }}
+      flutter_version: ${{ steps.version.outputs.flutter_version }}
+
+    steps:
+      - name: Check out repository metadata
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Select and validate target commit
+        id: target
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+          DISTRIBUTE_INTERNAL: ${{ inputs.distribute_internal }}
+          SUBMISSION_SOURCE: ${{ inputs.submission_source }}
+          CALLER_WORKFLOW_PATH: ${{ inputs.caller_workflow_path }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if [[ ! "$REQUESTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::commit_sha must be a full 40-character SHA"
+            exit 1
+          fi
+          target_sha="$(git rev-parse --verify "${REQUESTED_SHA}^{commit}")" || {
+            echo "::error::commit_sha does not identify an available commit"
+            exit 1
+          }
+          if ! git merge-base --is-ancestor "$target_sha" origin/main; then
+            echo "::error::Selected commit is not part of origin/main history"
+            exit 1
+          fi
+          case "$SUBMISSION_SOURCE:$DISTRIBUTE_INTERNAL:$CALLER_WORKFLOW_PATH" in
+            testflight:true:.github/workflows/deploy-testflight.yml|direct_review:false:.github/workflows/build-submit-app-store-review.yml) ;;
+            *)
+              echo "::error::submission source, distribution mode, and caller workflow do not match"
+              exit 1
+              ;;
+          esac
+          echo "sha=$target_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check out target commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Read release versions
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          flutter_version="$(jq -er '.flutterSdkVersion | strings | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' .fvm/fvm_config.json)"
+          [[ "$flutter_version" == "3.44.8" ]] || {
+            echo "::error::.fvm/fvm_config.json must select Flutter 3.44.8 for App Store builds"
+            exit 1
+          }
+          version_line="$(grep -E '^version:' pubspec.yaml || true)"
+          if [[ ! "$version_line" =~ ^version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+)(\+[0-9]+)?[[:space:]]*$ ]]; then
+            echo "::error::pubspec.yaml version must be numeric x.y.z or x.y.z+build"
+            exit 1
+          fi
+          {
+            echo "flutter_version=$flutter_version"
+            echo "app_version=${BASH_REMATCH[1]}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Flutter from FVM config
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ steps.version.outputs.flutter_version }}
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          dart pub global activate fvm 3.2.1
+          export PATH="$HOME/.pub-cache/bin:$PATH"
+          fvm flutter pub get
+
+      - name: Analyze
+        run: fvm flutter analyze
+
+      - name: Test
+        run: fvm flutter test
+
+  build:
+    name: Build and upload iOS app
+    needs: preflight
+    runs-on: macos-15
+    environment: testflight
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: app
+    outputs:
+      app_version: ${{ needs.preflight.outputs.app_version }}
+      build_number: ${{ github.run_id }}
+      commit_sha: ${{ needs.preflight.outputs.commit_sha }}
+      build_id: ${{ steps.distribution.outputs.build_id }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+      TESTFLIGHT_INTERNAL_GROUP: ${{ vars.TESTFLIGHT_INTERNAL_GROUP }}
+
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          path: _release_automation
+
+      - name: Check out target commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.preflight.outputs.commit_sha }}
+          fetch-depth: 0
+          path: app
+
+      - name: Validate App Store build configuration
+        shell: bash
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            APP_BUNDLE_ID \
+            APPLE_TEAM_ID \
+            TESTFLIGHT_INTERNAL_GROUP \
+            IOS_DISTRIBUTION_CERTIFICATE_BASE64 \
+            IOS_DISTRIBUTION_CERTIFICATE_PASSWORD \
+            IOS_APP_STORE_PROVISIONING_PROFILE_BASE64 \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_KEY_ID \
+            APP_STORE_CONNECT_PRIVATE_KEY; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing testflight environment setting: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          [[ "$APP_BUNDLE_ID" =~ ^[A-Za-z0-9.-]+$ ]] || {
+            echo "::error::APP_BUNDLE_ID contains invalid characters"
+            exit 1
+          }
+          [[ "$APPLE_TEAM_ID" =~ ^[A-Z0-9]{10}$ ]] || {
+            echo "::error::APPLE_TEAM_ID must be a ten-character Apple Team ID"
+            exit 1
+          }
+
+      - name: Validate App Store Xcode requirements
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -d "$DEVELOPER_DIR" ]]; then
+            echo "::error::Configured Xcode was not found at $DEVELOPER_DIR"
+            exit 1
+          fi
+          xcode_version="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
+          ios_sdk_version="$(xcrun --sdk iphoneos --show-sdk-version)"
+          [[ "$xcode_version" =~ ^([0-9]+)(\.|$) ]] || {
+            echo "::error::Could not determine the selected Xcode version: $xcode_version"
+            exit 1
+          }
+          xcode_major="${BASH_REMATCH[1]}"
+          (( xcode_major >= 26 )) || {
+            echo "::error::Xcode 26 or later is required by App Store Connect; selected $xcode_version"
+            exit 1
+          }
+          [[ "$ios_sdk_version" =~ ^([0-9]+)(\.|$) ]] || {
+            echo "::error::Could not determine the selected iOS SDK version: $ios_sdk_version"
+            exit 1
+          }
+          sdk_major="${BASH_REMATCH[1]}"
+          (( sdk_major >= 26 )) || {
+            echo "::error::iOS SDK 26 or later is required by App Store Connect; selected $ios_sdk_version"
+            exit 1
+          }
+          printf 'Using Xcode %s with iOS SDK %s\n' "$xcode_version" "$ios_sdk_version"
+
+      - name: Set up Flutter from FVM config
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ needs.preflight.outputs.flutter_version }}
+          channel: stable
+          cache: true
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          dart pub global activate fvm 3.2.1
+          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.pub-cache/bin:$PATH"
+          gem install fastlane --version 2.228.0 --no-document
+          gem install cocoapods --version 1.16.2 --no-document
+          fvm flutter pub get
+
+      - name: Install signing materials
+        id: signing
+        shell: bash
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/app-store-signing.keychain-db"
+          certificate="$RUNNER_TEMP/distribution.p12"
+          profile="$RUNNER_TEMP/app-store.mobileprovision"
+          keychain_password="$(uuidgen)$(uuidgen)"
+          rm -f "$RUNNER_TEMP/installed-profile-path"
+          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$certificate"
+          printf '%s' "$IOS_APP_STORE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          signing_identities="$(security find-identity -v -p codesigning "$keychain")"
+          grep -Fq '"Apple Distribution:' <<<"$signing_identities" || {
+            echo "::error::The imported certificate does not contain a valid Apple Distribution identity"
+            exit 1
+          }
+
+          profile_plist="$RUNNER_TEMP/profile.plist"
+          security cms -D -i "$profile" > "$profile_plist"
+          python3 - "$profile_plist" "$APPLE_TEAM_ID" "$APP_BUNDLE_ID" <<'PY'
+          import datetime
+          import plistlib
+          import sys
+
+          path, expected_team, bundle_id = sys.argv[1:]
+          with open(path, "rb") as file:
+              profile = plistlib.load(file)
+          team_ids = profile.get("TeamIdentifier", [])
+          prefixes = profile.get("ApplicationIdentifierPrefix", [])
+          entitlements = profile.get("Entitlements", {})
+          app_identifier = entitlements.get("application-identifier")
+          team_identifier = entitlements.get("com.apple.developer.team-identifier")
+          expected_app_identifiers = {f"{prefix}.{bundle_id}" for prefix in prefixes}
+          expiration = profile.get("ExpirationDate")
+          now = datetime.datetime.now(datetime.timezone.utc)
+          if isinstance(expiration, datetime.datetime) and expiration.tzinfo is None:
+              expiration = expiration.replace(tzinfo=datetime.timezone.utc)
+          errors = []
+          if expected_team not in team_ids or team_identifier != expected_team:
+              errors.append("Team ID does not match")
+          if app_identifier not in expected_app_identifiers:
+              errors.append("Bundle ID does not match")
+          if entitlements.get("get-task-allow") is not False:
+              errors.append("profile allows development debugging")
+          if "ProvisionedDevices" in profile:
+              errors.append("profile is device-scoped instead of App Store distribution")
+          if profile.get("ProvisionsAllDevices") is True:
+              errors.append("profile is an enterprise profile instead of App Store distribution")
+          if not isinstance(expiration, datetime.datetime) or expiration <= now:
+              errors.append("profile is expired or has no valid expiration date")
+          if errors:
+              for error in errors:
+                  print(f"::error::Invalid App Store provisioning profile: {error}")
+              sys.exit(1)
+          PY
+          profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+          profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          installed_profile="$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
+          printf '%s' "$installed_profile" > "$RUNNER_TEMP/installed-profile-path"
+          cp "$profile" "$installed_profile"
+          echo "profile_name=$profile_name" >> "$GITHUB_OUTPUT"
+
+      - name: Generate export options and App Store Connect key
+        shell: bash
+        env:
+          PROFILE_NAME: ${{ steps.signing.outputs.profile_name }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' \
+            '<?xml version="1.0" encoding="UTF-8"?>' \
+            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+            '<plist version="1.0"><dict>' \
+            '<key>method</key><string>app-store-connect</string>' \
+            '<key>signingStyle</key><string>manual</string>' \
+            "<key>teamID</key><string>$APPLE_TEAM_ID</string>" \
+            '<key>provisioningProfiles</key><dict>' \
+            "<key>$APP_BUNDLE_ID</key><string>$PROFILE_NAME</string>" \
+            '</dict><key>uploadBitcode</key><false/><key>uploadSymbols</key><true/>' \
+            '</dict></plist>' > "$RUNNER_TEMP/ExportOptions.plist"
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --rawfile key "$RUNNER_TEMP/AuthKey.p8" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$RUNNER_TEMP/app-store-connect-key.json"
+
+      - name: Validate manual internal TestFlight group
+        shell: bash
+        env:
+          DISTRIBUTE_INTERNAL: ${{ inputs.distribute_internal }}
+        run: |
+          set -euo pipefail
+          if [[ "$DISTRIBUTE_INTERNAL" == "true" ]]; then
+            ruby ../_release_automation/script/testflight-internal-group.rb validate-manual \
+              "$RUNNER_TEMP/app-store-connect-key.json" \
+              "$APP_BUNDLE_ID" \
+              "$TESTFLIGHT_INTERNAL_GROUP"
+          fi
+
+      - name: Build signed IPA
+        id: build
+        shell: bash
+        env:
+          PROFILE_NAME: ${{ steps.signing.outputs.profile_name }}
+          APP_VERSION: ${{ needs.preflight.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          fvm flutter build ios \
+            --release \
+            --config-only \
+            --build-name "$APP_VERSION" \
+            --build-number "${{ github.run_id }}"
+          APP_BUNDLE_ID="$APP_BUNDLE_ID" \
+          APPLE_TEAM_ID="$APPLE_TEAM_ID" \
+          PROFILE_NAME="$PROFILE_NAME" \
+            ruby ../_release_automation/script/configure-ios-signing.rb
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/Runner.xcarchive" \
+            archive
+          mkdir -p build/ios/ipa
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$RUNNER_TEMP/Runner.xcarchive" \
+            -exportPath build/ios/ipa \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+
+      - name: Upload and wait for App Store Connect processing
+        shell: bash
+        run: |
+          set -euo pipefail
+          ipa="$(find build/ios/ipa -maxdepth 1 -type f -name '*.ipa' -print -quit)"
+          [[ -n "$ipa" ]] || { echo "::error::Built IPA was not found"; exit 1; }
+          fastlane pilot upload \
+            --ipa "$ipa" \
+            --api_key_path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --app_identifier "$APP_BUNDLE_ID" \
+            --skip_submission true \
+            --skip_waiting_for_build_processing false \
+            --wait_processing_interval 30 \
+            --wait_processing_timeout_duration 1800
+
+      - name: Apply and verify TestFlight distribution policy
+        id: distribution
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.build.outputs.app_version }}
+          DISTRIBUTE_INTERNAL: ${{ inputs.distribute_internal }}
+        run: |
+          set -euo pipefail
+          if [[ "$DISTRIBUTE_INTERNAL" == "true" ]]; then
+            result="$(ruby ../_release_automation/script/testflight-internal-group.rb assign-build \
+              "$RUNNER_TEMP/app-store-connect-key.json" \
+              "$APP_BUNDLE_ID" \
+              "$TESTFLIGHT_INTERNAL_GROUP" \
+              "$APP_VERSION" \
+              "$GITHUB_RUN_ID" \
+              300)"
+            internal_distributed=true
+          else
+            result="$(ruby ../_release_automation/script/testflight-internal-group.rb assert-no-groups \
+              "$RUNNER_TEMP/app-store-connect-key.json" \
+              "$APP_BUNDLE_ID" \
+              "$TESTFLIGHT_INTERNAL_GROUP" \
+              "$APP_VERSION" \
+              "$GITHUB_RUN_ID" \
+              300)"
+            internal_distributed=false
+          fi
+          echo "build_id=$(jq -r '.build_id' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "internal_distributed=$internal_distributed" >> "$GITHUB_OUTPUT"
+
+      - name: Write build provenance
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.build.outputs.app_version }}
+          BUILD_ID: ${{ steps.distribution.outputs.build_id }}
+          COMMIT_SHA: ${{ needs.preflight.outputs.commit_sha }}
+          INTERNAL_DISTRIBUTED: ${{ steps.distribution.outputs.internal_distributed }}
+          SUBMISSION_SOURCE: ${{ inputs.submission_source }}
+          CALLER_WORKFLOW_NAME: ${{ inputs.caller_workflow_name }}
+          CALLER_WORKFLOW_PATH: ${{ inputs.caller_workflow_path }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg workflow_name "$CALLER_WORKFLOW_NAME" \
+            --arg workflow_path "$CALLER_WORKFLOW_PATH" \
+            --arg build_workflow_path ".github/workflows/build-ios-app-store.yml" \
+            --arg app_version "$APP_VERSION" \
+            --arg build_number "$GITHUB_RUN_ID" \
+            --arg build_id "$BUILD_ID" \
+            --arg commit_sha "$COMMIT_SHA" \
+            --arg submission_source "$SUBMISSION_SOURCE" \
+            --argjson internal_distributed "$INTERNAL_DISTRIBUTED" \
+            '{
+              run_id: $run_id,
+              repository: $repository,
+              workflow_name: $workflow_name,
+              workflow_path: $workflow_path,
+              build_workflow_path: $build_workflow_path,
+              app_version: $app_version,
+              build_number: $build_number,
+              build_id: $build_id,
+              commit_sha: $commit_sha,
+              submission_source: $submission_source,
+              internal_distributed: $internal_distributed
+            }' > "$RUNNER_TEMP/app-store-build-provenance.json"
+
+      - name: Upload build provenance
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: app-store-build-provenance-${{ github.run_id }}
+          path: ${{ runner.temp }}/app-store-build-provenance.json
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 90
+
+      - name: Write build summary
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.build.outputs.app_version }}
+          BUILD_ID: ${{ steps.distribution.outputs.build_id }}
+          COMMIT_SHA: ${{ needs.preflight.outputs.commit_sha }}
+          INTERNAL_DISTRIBUTED: ${{ steps.distribution.outputs.internal_distributed }}
+          SUBMISSION_SOURCE: ${{ inputs.submission_source }}
+        run: |
+          {
+            echo "## App Store Connect build"
+            echo
+            echo "- App version: \`$APP_VERSION\`"
+            echo "- Build number: \`$GITHUB_RUN_ID\`"
+            echo "- Build ID: \`$BUILD_ID\`"
+            echo "- Commit SHA: \`$COMMIT_SHA\`"
+            echo "- Submission source: \`$SUBMISSION_SOURCE\`"
+            echo "- Internal distributed: \`$INTERNAL_DISTRIBUTED\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up signing materials
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          security delete-keychain "$RUNNER_TEMP/app-store-signing.keychain-db" 2>/dev/null
+          if [[ -f "$RUNNER_TEMP/installed-profile-path" ]]; then
+            profile_path="$(<"$RUNNER_TEMP/installed-profile-path")"
+            profile_root="$HOME/Library/MobileDevice/Provisioning Profiles/"
+            if [[ "$profile_path" == "$profile_root"*.mobileprovision ]]; then
+              rm -f "$profile_path"
+            fi
+          fi
+          rm -f \
+            "$RUNNER_TEMP/AuthKey.p8" \
+            "$RUNNER_TEMP/app-store-connect-key.json" \
+            "$RUNNER_TEMP/ExportOptions.plist" \
+            "$RUNNER_TEMP/distribution.p12" \
+            "$RUNNER_TEMP/app-store.mobileprovision" \
+            "$RUNNER_TEMP/profile.plist" \
+            "$RUNNER_TEMP/installed-profile-path" \
+            "$RUNNER_TEMP/app-store-build-provenance.json"
+          rm -rf "$RUNNER_TEMP/Runner.xcarchive"

--- a/.github/workflows/build-ios-app-store.yml
+++ b/.github/workflows/build-ios-app-store.yml
@@ -354,17 +354,26 @@ jobs:
           APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          printf '%s\n' \
-            '<?xml version="1.0" encoding="UTF-8"?>' \
-            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
-            '<plist version="1.0"><dict>' \
-            '<key>method</key><string>app-store-connect</string>' \
-            '<key>signingStyle</key><string>manual</string>' \
-            "<key>teamID</key><string>$APPLE_TEAM_ID</string>" \
-            '<key>provisioningProfiles</key><dict>' \
-            "<key>$APP_BUNDLE_ID</key><string>$PROFILE_NAME</string>" \
-            '</dict><key>uploadBitcode</key><false/><key>uploadSymbols</key><true/>' \
-            '</dict></plist>' > "$RUNNER_TEMP/ExportOptions.plist"
+          python3 - \
+            "$RUNNER_TEMP/ExportOptions.plist" \
+            "$APP_BUNDLE_ID" \
+            "$PROFILE_NAME" \
+            "$APPLE_TEAM_ID" <<'PY'
+          import plistlib
+          import sys
+
+          path, bundle_id, profile_name, team_id = sys.argv[1:]
+          options = {
+              "method": "app-store-connect",
+              "signingStyle": "manual",
+              "teamID": team_id,
+              "provisioningProfiles": {bundle_id: profile_name},
+              "uploadBitcode": False,
+              "uploadSymbols": True,
+          }
+          with open(path, "wb") as file:
+              plistlib.dump(options, file, sort_keys=False)
+          PY
           printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
           jq -n \
             --arg key_id "$APP_STORE_CONNECT_KEY_ID" \

--- a/.github/workflows/build-submit-app-store-review.yml
+++ b/.github/workflows/build-submit-app-store-review.yml
@@ -1,0 +1,272 @@
+name: Build and Submit App Store Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "main上の審査対象commit SHA（40文字）"
+        required: true
+        type: string
+      whats_new_ja:
+        description: "App Storeに表示する日本語の「このバージョンの新機能」"
+        required: true
+        type: string
+      review_notes:
+        description: "App Review向けの補足（空欄なら既存値を保持）"
+        required: false
+        type: string
+
+concurrency:
+  group: app-store-review-submission
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build without TestFlight distribution
+    if: ${{ github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/build-ios-app-store.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      distribute_internal: false
+      submission_source: direct_review
+      caller_workflow_name: Build and Submit App Store Review
+      caller_workflow_path: .github/workflows/build-submit-app-store-review.yml
+    secrets: inherit
+
+  submit:
+    name: Submit direct build to App Review
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    environment: testflight
+    timeout-minutes: 20
+    env:
+      APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+      APP_VERSION: ${{ needs.build.outputs.app_version }}
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+      BUILD_ID: ${{ needs.build.outputs.build_id }}
+      COMMIT_SHA: ${{ needs.build.outputs.commit_sha }}
+      WHATS_NEW_JA: ${{ inputs.whats_new_ja }}
+      REVIEW_NOTES: ${{ inputs.review_notes }}
+
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Validate direct review request
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            APP_BUNDLE_ID \
+            APP_VERSION \
+            BUILD_NUMBER \
+            BUILD_ID \
+            COMMIT_SHA \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_KEY_ID \
+            APP_STORE_CONNECT_PRIVATE_KEY; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing direct review setting: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::App version must be numeric x.y.z"
+            exit 1
+          }
+          [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]] || {
+            echo "::error::Build number must contain digits only"
+            exit 1
+          }
+          [[ "$BUILD_ID" =~ ^[^[:space:]]+$ ]] || {
+            echo "::error::Build ID must not be blank"
+            exit 1
+          }
+          [[ "$COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || {
+            echo "::error::Commit SHA must be a full 40-character SHA"
+            exit 1
+          }
+          [[ "$WHATS_NEW_JA" =~ [^[:space:]] ]] || {
+            echo "::error::whats_new_ja must not be blank"
+            exit 1
+          }
+
+      - name: Download direct build provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: app-store-build-provenance-${{ github.run_id }}
+          path: "$RUNNER_TEMP/direct-provenance"
+
+      - name: Verify direct build provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          provenance="$RUNNER_TEMP/direct-provenance/app-store-build-provenance.json"
+          [[ -f "$provenance" ]] || {
+            echo "::error::Direct build provenance artifact is missing"
+            exit 1
+          }
+          jq -e \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg app_version "$APP_VERSION" \
+            --arg build_number "$BUILD_NUMBER" \
+            --arg build_id "$BUILD_ID" \
+            --arg commit_sha "$COMMIT_SHA" \
+            '.run_id == $run_id and
+             .repository == $repository and
+             .workflow_name == "Build and Submit App Store Review" and
+             .workflow_path == ".github/workflows/build-submit-app-store-review.yml" and
+             .build_workflow_path == ".github/workflows/build-ios-app-store.yml" and
+             .app_version == $app_version and
+             .build_number == $build_number and
+             .build_id == $build_id and
+             .commit_sha == $commit_sha and
+             .submission_source == "direct_review" and
+             .internal_distributed == false' \
+            "$provenance" >/dev/null || {
+              echo "::error::Direct build provenance does not match this review request"
+              exit 1
+            }
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install App Store dependencies
+        run: |
+          gem install jwt --version 2.10.2 --no-document
+          gem install fastlane --version 2.228.0 --no-document
+
+      - name: Create App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --rawfile key "$RUNNER_TEMP/AuthKey.p8" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$RUNNER_TEMP/app-store-connect-key.json"
+
+      - name: Prepare App Store version
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby script/app_store_release.rb prepare \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION"
+
+      - name: Preflight direct App Store review
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$(ruby script/app_store_release.rb preflight \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION" \
+            --build-number "$BUILD_NUMBER" \
+            --distribution-mode none \
+            --whats-new "$WHATS_NEW_JA" \
+            --review-notes "$REVIEW_NOTES")"
+          actual_build_id="$(jq -r '.build_id' <<<"$result")"
+          if [[ "$actual_build_id" != "$BUILD_ID" ]]; then
+            echo "::error::App Store build ID does not match build provenance"
+            exit 1
+          fi
+          {
+            echo "status=$(jq -r '.status' <<<"$result")"
+            echo "app_id=$(jq -r '.app_id' <<<"$result")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update App Store metadata and build
+        if: ${{ steps.preflight.outputs.status == 'ready' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby script/app_store_release.rb update-metadata \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION" \
+            --build-number "$BUILD_NUMBER" \
+            --distribution-mode none \
+            --whats-new "$WHATS_NEW_JA" \
+            --review-notes "$REVIEW_NOTES"
+
+      - name: Submit direct build for review
+        id: submit
+        if: ${{ steps.preflight.outputs.status == 'ready' }}
+        shell: bash
+        run: >-
+          fastlane deliver submit_build
+          --api_key_path "$RUNNER_TEMP/app-store-connect-key.json"
+          --app_identifier "$APP_BUNDLE_ID"
+          --app_version "$APP_VERSION"
+          --build_number "$BUILD_NUMBER"
+          --submit_for_review true
+          --skip_binary_upload true
+          --skip_screenshots true
+          --skip_metadata true
+          --automatic_release false
+          --precheck_default_rule_level error
+          --precheck_include_in_app_purchases false
+          --submission_information '{"export_compliance_uses_encryption": false}'
+          --force true
+
+      - name: Write direct review summary
+        if: always()
+        shell: bash
+        env:
+          APP_ID: ${{ steps.preflight.outputs.app_id }}
+          PREFLIGHT_STATUS: ${{ steps.preflight.outputs.status }}
+          SUBMIT_OUTCOME: ${{ steps.submit.outcome }}
+        run: |
+          result="failed"
+          if [[ "$SUBMIT_OUTCOME" == "success" ]]; then
+            result="submitted"
+          elif [[ "$PREFLIGHT_STATUS" == "already_submitted" ]]; then
+            result="already-submitted"
+          fi
+          {
+            echo "## Direct App Store review submission"
+            echo
+            echo "- App version: \`$APP_VERSION\`"
+            echo "- Build number: \`$BUILD_NUMBER\`"
+            echo "- Build ID: \`$BUILD_ID\`"
+            echo "- Commit SHA: \`$COMMIT_SHA\`"
+            echo "- Internal TestFlight distribution: \`false\`"
+            echo "- Result: \`$result\`"
+            if [[ -n "$APP_ID" ]]; then
+              echo "- App Store Connect: https://appstoreconnect.apple.com/apps/$APP_ID/appstore"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up App Store Connect key
+        if: always()
+        shell: bash
+        run: |
+          rm -f \
+            "$RUNNER_TEMP/AuthKey.p8" \
+            "$RUNNER_TEMP/app-store-connect-key.json"
+          rm -rf "$RUNNER_TEMP/direct-provenance"

--- a/.github/workflows/build-submit-app-store-review.yml
+++ b/.github/workflows/build-submit-app-store-review.yml
@@ -24,8 +24,115 @@ permissions:
   contents: read
 
 jobs:
+  preflight-target:
+    name: Validate target App Store state
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    environment: testflight
+    timeout-minutes: 15
+    env:
+      APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Validate target commit
+        id: target
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUESTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::commit_sha must be a full 40-character SHA"
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          target_sha="$(git rev-parse --verify "${REQUESTED_SHA}^{commit}")" || {
+            echo "::error::commit_sha does not identify an available commit"
+            exit 1
+          }
+          if ! git merge-base --is-ancestor "$target_sha" origin/main; then
+            echo "::error::Selected commit is not part of origin/main history"
+            exit 1
+          fi
+          echo "sha=$target_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check out target commit metadata
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          fetch-depth: 1
+          path: target
+
+      - name: Read target App version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_line="$(grep -E '^version:' target/pubspec.yaml || true)"
+          if [[ ! "$version_line" =~ ^version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+)(\+[0-9]+)?[[:space:]]*$ ]]; then
+            echo "::error::target pubspec.yaml version must be numeric x.y.z or x.y.z+build"
+            exit 1
+          fi
+          echo "app_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install App Store API dependency
+        run: gem install jwt --version 2.10.2 --no-document
+
+      - name: Create App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in APP_BUNDLE_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing target preflight setting: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --rawfile key "$RUNNER_TEMP/AuthKey.p8" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$RUNNER_TEMP/app-store-connect-key.json"
+
+      - name: Check target App Store state before build
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.version.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          ruby script/app_store_release.rb prepare-check \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION"
+
+      - name: Clean up target preflight key
+        if: always()
+        shell: bash
+        run: |
+          rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/app-store-connect-key.json"
+
   build:
     name: Build without TestFlight distribution
+    needs: preflight-target
     if: ${{ github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/build-ios-app-store.yml
     with:

--- a/.github/workflows/build-submit-app-store-review.yml
+++ b/.github/workflows/build-submit-app-store-review.yml
@@ -119,7 +119,7 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.app_version }}
         run: |
           set -euo pipefail
-          ruby script/app_store_release.rb prepare-check \
+          ruby script/app_store_release.rb preflight --prepare-only \
             --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
             --bundle-id "$APP_BUNDLE_ID" \
             --app-version "$APP_VERSION"

--- a/.github/workflows/build-submit-app-store-review.yml
+++ b/.github/workflows/build-submit-app-store-review.yml
@@ -32,6 +32,8 @@ jobs:
     timeout-minutes: 15
     env:
       APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+    outputs:
+      build_allowed: ${{ steps.target-state.outputs.build_allowed }}
 
     steps:
       - name: Check out release automation
@@ -114,15 +116,56 @@ jobs:
             > "$RUNNER_TEMP/app-store-connect-key.json"
 
       - name: Check target App Store state before build
+        id: target-state
         shell: bash
         env:
           APP_VERSION: ${{ steps.version.outputs.app_version }}
         run: |
           set -euo pipefail
-          ruby script/app_store_release.rb preflight --prepare-only \
+          result="$(ruby script/app_store_release.rb preflight --prepare-only \
             --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
             --bundle-id "$APP_BUNDLE_ID" \
-            --app-version "$APP_VERSION"
+            --app-version "$APP_VERSION")"
+          action="$(jq -er '.action | strings' <<<"$result")"
+          echo "action=$action" >> "$GITHUB_OUTPUT"
+          case "$action" in
+            would_create|reused)
+              echo "build_allowed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            skipped)
+              echo "build_allowed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown target preflight action: $action"
+              exit 1
+              ;;
+          esac
+
+      - name: Write target preflight summary
+        if: always()
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.version.outputs.app_version }}
+          TARGET_ACTION: ${{ steps.target-state.outputs.action }}
+          BUILD_ALLOWED: ${{ steps.target-state.outputs.build_allowed }}
+          TARGET_OUTCOME: ${{ steps.target-state.outcome }}
+        run: |
+          result="$TARGET_ACTION"
+          detail="Target state permits the direct App Store build."
+          if [[ "$TARGET_OUTCOME" != "success" ]]; then
+            result="failed"
+            detail="Target App Store state preflight failed; no build was started."
+          elif [[ "$TARGET_ACTION" == "skipped" ]]; then
+            detail="Target version is already live or older; no build or upload was started."
+          fi
+          {
+            echo "## Direct App Store target preflight"
+            echo
+            echo "- App version: \`$APP_VERSION\`"
+            echo "- Result: \`$result\`"
+            echo "- Build allowed: \`$BUILD_ALLOWED\`"
+            echo "- Detail: $detail"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up target preflight key
         if: always()
@@ -133,7 +176,7 @@ jobs:
   build:
     name: Build without TestFlight distribution
     needs: preflight-target
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ needs.preflight-target.outputs.build_allowed == 'true' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/build-ios-app-store.yml
     with:
       commit_sha: ${{ inputs.commit_sha }}
@@ -146,7 +189,7 @@ jobs:
   submit:
     name: Submit direct build to App Review
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ needs.build.result == 'success' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     environment: testflight
     timeout-minutes: 20

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -1,0 +1,141 @@
+name: Deploy TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "main上の配布対象commit SHA（40文字）"
+        required: true
+        type: string
+
+concurrency:
+  group: testflight-deployment
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and distribute to internal TestFlight
+    if: ${{ github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/build-ios-app-store.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      distribute_internal: true
+      submission_source: testflight
+      caller_workflow_name: Deploy TestFlight
+      caller_workflow_path: .github/workflows/deploy-testflight.yml
+    secrets: inherit
+
+  prepare-app-store-version:
+    name: Prepare App Store version
+    needs: build
+    runs-on: ubuntu-24.04
+    environment: testflight
+    timeout-minutes: 10
+    env:
+      APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+      APP_VERSION: ${{ needs.build.outputs.app_version }}
+      BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+      COMMIT_SHA: ${{ needs.build.outputs.commit_sha }}
+
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Validate App Store preparation configuration
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            APP_BUNDLE_ID \
+            APP_VERSION \
+            BUILD_NUMBER \
+            COMMIT_SHA \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_KEY_ID \
+            APP_STORE_CONNECT_PRIVATE_KEY; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing App Store preparation setting: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install App Store API dependency
+        run: gem install jwt --version 2.10.2 --no-document
+
+      - name: Create App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --rawfile key "$RUNNER_TEMP/AuthKey.p8" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$RUNNER_TEMP/app-store-connect-key.json"
+
+      - name: Prepare App Store version
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$(ruby script/app_store_release.rb prepare \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION")"
+          {
+            echo "action=$(jq -r '.action' <<<"$result")"
+            echo "version_id=$(jq -r '.version_id // \"\"' <<<"$result")"
+            echo "message=$(jq -r '.message' <<<"$result")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write App Store version preparation summary
+        if: always()
+        shell: bash
+        env:
+          PREPARE_ACTION: ${{ steps.prepare.outputs.action }}
+          PREPARE_MESSAGE: ${{ steps.prepare.outputs.message }}
+          PREPARE_OUTCOME: ${{ steps.prepare.outcome }}
+        run: |
+          result="$PREPARE_ACTION"
+          detail="$PREPARE_MESSAGE"
+          if [[ "$PREPARE_OUTCOME" != "success" ]]; then
+            result="failed"
+            detail="Internal TestFlight distribution succeeded, but App Store version preparation failed."
+          fi
+          {
+            echo "## App Store version preparation"
+            echo
+            echo "- App version: \`$APP_VERSION\`"
+            echo "- Build number: \`$BUILD_NUMBER\`"
+            echo "- Commit SHA: \`$COMMIT_SHA\`"
+            echo "- Result: \`$result\`"
+            echo "- Detail: $detail"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up App Store Connect key
+        if: always()
+        shell: bash
+        run: |
+          rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/app-store-connect-key.json"

--- a/.github/workflows/submit-app-store-review.yml
+++ b/.github/workflows/submit-app-store-review.yml
@@ -104,6 +104,7 @@ jobs:
             '.id == $run_id and
              .name == "Deploy TestFlight" and
              .path == ".github/workflows/deploy-testflight.yml" and
+             .event == "workflow_dispatch" and
              .head_branch == "main" and
              .conclusion == "success"' \
             <<<"$run" >/dev/null; then
@@ -130,7 +131,6 @@ jobs:
             --arg repository "$GITHUB_REPOSITORY" \
             --arg app_version "$APP_VERSION" \
             --arg build_number "$BUILD_NUMBER" \
-            --arg head_sha "$(jq -r '.head_sha' <<<"$run")" \
             '.run_id == $run_id and
              .repository == $repository and
              .workflow_name == "Deploy TestFlight" and
@@ -139,7 +139,6 @@ jobs:
              .app_version == $app_version and
              .build_number == $build_number and
              (.build_id | type == "string" and length > 0) and
-             .commit_sha == $head_sha and
              .submission_source == "testflight" and
              .internal_distributed == true and
              (.commit_sha | type == "string" and test("^[0-9a-f]{40}$"))' \

--- a/.github/workflows/submit-app-store-review.yml
+++ b/.github/workflows/submit-app-store-review.yml
@@ -1,0 +1,297 @@
+name: Submit App Store Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: "TestFlightで確認したApp version（例: 1.0.1）"
+        required: true
+        type: string
+      build_number:
+        description: "Deploy TestFlightのSummaryに表示されたBuild number"
+        required: true
+        type: string
+      whats_new_ja:
+        description: "App Storeに表示する日本語の「このバージョンの新機能」"
+        required: true
+        type: string
+      review_notes:
+        description: "App Review向けの補足（空欄なら既存値を保持）"
+        required: false
+        type: string
+
+concurrency:
+  group: app-store-review-submission
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  submit:
+    name: Submit tested build to App Review
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    environment: testflight
+    timeout-minutes: 20
+    env:
+      APP_BUNDLE_ID: ${{ vars.APP_BUNDLE_ID }}
+      APP_VERSION: ${{ inputs.app_version }}
+      BUILD_NUMBER: ${{ inputs.build_number }}
+      WHATS_NEW_JA: ${{ inputs.whats_new_ja }}
+      REVIEW_NOTES: ${{ inputs.review_notes }}
+      TESTFLIGHT_INTERNAL_GROUP: ${{ vars.TESTFLIGHT_INTERNAL_GROUP }}
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Validate release request
+        id: validate
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::App Store review submission must run from main"
+            exit 1
+          fi
+
+          missing=()
+          for name in \
+            APP_BUNDLE_ID \
+            TESTFLIGHT_INTERNAL_GROUP \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_KEY_ID \
+            APP_STORE_CONNECT_PRIVATE_KEY; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf '::error::Missing App Store review setting: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          if [[ ! "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::app_version must be numeric x.y.z"
+            exit 1
+          fi
+          if [[ ! "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::build_number must contain digits only"
+            exit 1
+          fi
+          if [[ ! "$WHATS_NEW_JA" =~ [^[:space:]] ]]; then
+            echo "::error::whats_new_ja must not be blank"
+            exit 1
+          fi
+
+      - name: Resolve TestFlight provenance
+        id: provenance
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$BUILD_NUMBER")"
+          if ! jq -e \
+            --argjson run_id "$BUILD_NUMBER" \
+            '.id == $run_id and
+             .name == "Deploy TestFlight" and
+             .path == ".github/workflows/deploy-testflight.yml" and
+             .head_branch == "main" and
+             .conclusion == "success"' \
+            <<<"$run" >/dev/null; then
+            echo "::error::build_number must identify a successful Deploy TestFlight run on main"
+            exit 1
+          fi
+
+          artifact_name="app-store-build-provenance-$BUILD_NUMBER"
+          artifacts="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$BUILD_NUMBER/artifacts")"
+          artifact_id="$(jq -er \
+            --arg name "$artifact_name" \
+            '[.artifacts[] | select(.name == $name and .expired == false)] |
+             if length == 1 then .[0].id else error("expected exactly one unexpired provenance artifact") end' \
+            <<<"$artifacts")"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" \
+            > "$RUNNER_TEMP/app-store-build-provenance.zip"
+          provenance="$(unzip -p \
+            "$RUNNER_TEMP/app-store-build-provenance.zip" \
+            app-store-build-provenance.json)"
+
+          if ! jq -e \
+            --argjson run_id "$BUILD_NUMBER" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg app_version "$APP_VERSION" \
+            --arg build_number "$BUILD_NUMBER" \
+            --arg head_sha "$(jq -r '.head_sha' <<<"$run")" \
+            '.run_id == $run_id and
+             .repository == $repository and
+             .workflow_name == "Deploy TestFlight" and
+             .workflow_path == ".github/workflows/deploy-testflight.yml" and
+             .build_workflow_path == ".github/workflows/build-ios-app-store.yml" and
+             .app_version == $app_version and
+             .build_number == $build_number and
+             (.build_id | type == "string" and length > 0) and
+             .commit_sha == $head_sha and
+             .submission_source == "testflight" and
+             .internal_distributed == true and
+             (.commit_sha | type == "string" and test("^[0-9a-f]{40}$"))' \
+            <<<"$provenance" >/dev/null; then
+            echo "::error::TestFlight provenance does not match the requested version and build"
+            exit 1
+          fi
+          {
+            echo "commit_sha=$(jq -r '.commit_sha' <<<"$provenance")"
+            echo "build_id=$(jq -r '.build_id' <<<"$provenance")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install App Store dependencies
+        run: |
+          gem install jwt --version 2.10.2 --no-document
+          gem install fastlane --version 2.228.0 --no-document
+
+      - name: Create App Store Connect API key
+        shell: bash
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          jq -n \
+            --arg key_id "$APP_STORE_CONNECT_KEY_ID" \
+            --arg issuer_id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --rawfile key "$RUNNER_TEMP/AuthKey.p8" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$RUNNER_TEMP/app-store-connect-key.json"
+
+      - name: Preflight App Store review
+        id: preflight
+        shell: bash
+        env:
+          EXPECTED_BUILD_ID: ${{ steps.provenance.outputs.build_id }}
+        run: |
+          set -euo pipefail
+          result="$(ruby script/app_store_release.rb preflight \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION" \
+            --build-number "$BUILD_NUMBER" \
+            --internal-group "$TESTFLIGHT_INTERNAL_GROUP" \
+            --distribution-mode internal \
+            --whats-new "$WHATS_NEW_JA" \
+            --review-notes "$REVIEW_NOTES")"
+          actual_build_id="$(jq -r '.build_id' <<<"$result")"
+          if [[ "$actual_build_id" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "::error::App Store build ID does not match TestFlight provenance"
+            exit 1
+          fi
+          {
+            echo "status=$(jq -r '.status' <<<"$result")"
+            echo "app_id=$(jq -r '.app_id' <<<"$result")"
+            echo "version_id=$(jq -r '.version_id' <<<"$result")"
+            echo "build_id=$(jq -r '.build_id' <<<"$result")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update App Store metadata and build
+        id: metadata
+        if: ${{ steps.preflight.outputs.status == 'ready' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby script/app_store_release.rb update-metadata \
+            --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
+            --bundle-id "$APP_BUNDLE_ID" \
+            --app-version "$APP_VERSION" \
+            --build-number "$BUILD_NUMBER" \
+            --internal-group "$TESTFLIGHT_INTERNAL_GROUP" \
+            --distribution-mode internal \
+            --whats-new "$WHATS_NEW_JA" \
+            --review-notes "$REVIEW_NOTES"
+
+      - name: Submit existing build for review
+        id: submit
+        if: ${{ steps.preflight.outputs.status == 'ready' }}
+        shell: bash
+        run: >-
+          fastlane deliver submit_build
+          --api_key_path "$RUNNER_TEMP/app-store-connect-key.json"
+          --app_identifier "$APP_BUNDLE_ID"
+          --app_version "$APP_VERSION"
+          --build_number "$BUILD_NUMBER"
+          --submit_for_review true
+          --skip_binary_upload true
+          --skip_screenshots true
+          --skip_metadata true
+          --automatic_release false
+          --precheck_default_rule_level error
+          --precheck_include_in_app_purchases false
+          --submission_information '{"export_compliance_uses_encryption": false}'
+          --force true
+
+      - name: Write App Store review summary
+        if: always()
+        shell: bash
+        env:
+          PREFLIGHT_STATUS: ${{ steps.preflight.outputs.status }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+          PROVENANCE_OUTCOME: ${{ steps.provenance.outcome }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
+          METADATA_OUTCOME: ${{ steps.metadata.outcome }}
+          SUBMIT_OUTCOME: ${{ steps.submit.outcome }}
+          COMMIT_SHA: ${{ steps.provenance.outputs.commit_sha }}
+        run: |
+          result="failed"
+          detail="Workflow setup or submission did not complete."
+          if [[ "$SUBMIT_OUTCOME" == "success" ]]; then
+            result="submitted"
+            detail="The tested build was submitted to App Review."
+          elif [[ "$PREFLIGHT_OUTCOME" == "success" && "$PREFLIGHT_STATUS" == "already_submitted" ]]; then
+            result="already-submitted"
+            detail="The same build is already waiting for review or under review."
+          else
+            for stage_outcome in \
+              "request validation:$VALIDATE_OUTCOME" \
+              "TestFlight provenance:$PROVENANCE_OUTCOME" \
+              "App Store preflight:$PREFLIGHT_OUTCOME" \
+              "metadata update:$METADATA_OUTCOME" \
+              "review submission:$SUBMIT_OUTCOME"; do
+              stage="${stage_outcome%%:*}"
+              outcome="${stage_outcome#*:}"
+              if [[ "$outcome" == "failure" ]]; then
+                detail="Failed during $stage. Check the corresponding step error."
+                break
+              fi
+            done
+          fi
+          {
+            echo "## App Store review submission"
+            echo
+            echo "- App version: \`$APP_VERSION\`"
+            echo "- Build number: \`$BUILD_NUMBER\`"
+            echo "- Commit SHA: \`${COMMIT_SHA:-unavailable}\`"
+            echo "- Result: \`$result\`"
+            echo "- Detail: $detail"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up App Store Connect key
+        if: always()
+        shell: bash
+        run: |
+          rm -f \
+            "$RUNNER_TEMP/AuthKey.p8" \
+            "$RUNNER_TEMP/app-store-connect-key.json" \
+            "$RUNNER_TEMP/app-store-build-provenance.zip"

--- a/.github/workflows/submit-app-store-review.yml
+++ b/.github/workflows/submit-app-store-review.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check out main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 1
 
       - name: Validate release request

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,136 @@
+# App Storeリリース手順
+
+このリポジトリのApp Storeリリースは、GitHub Actionsから明示的に起動した場合だけ実行されます。`main`へのpushやマージではApple側の状態を変更しません。審査提出後の公開は、Apple承認を確認してからApp Store Connectで手動操作します。
+
+審査までの経路は次の2つです。
+
+- **確認重視:** 内部TestFlightへ配布し、確認済みの同じbuildを審査へ提出する。
+- **審査直行:** TestFlightグループへ配布せず、mainのcommitからbuildして審査へ提出する。
+
+どちらも同じReusable iOS App Store Buildを使用します。共通buildは対象commit、App version、Build number、App Store Connectのbuild ID、workflow、配布経路をprovenance artifactに記録します。artifactは90日保持されます。
+
+## 初回設定
+
+### GitHub Environment
+
+リポジトリの`testflight` Environmentへ次のVariablesを登録します。値はこのドキュメント、Issue、workflow summaryへ書きません。
+
+- `APP_BUNDLE_ID`: App Store Connectへ登録したConquestのBundle ID
+- `APPLE_TEAM_ID`: Apple Developer Team ID
+- `TESTFLIGHT_INTERNAL_GROUP`: 自動配布を無効にした内部TestFlightグループ名
+
+同じEnvironmentへ次のSecretsを登録します。
+
+- `IOS_DISTRIBUTION_CERTIFICATE_BASE64`
+- `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD`
+- `IOS_APP_STORE_PROVISIONING_PROFILE_BASE64`
+- `APP_STORE_CONNECT_ISSUER_ID`
+- `APP_STORE_CONNECT_KEY_ID`
+- `APP_STORE_CONNECT_PRIVATE_KEY`
+
+証明書、profile、API keyはログやartifactへ出力しません。workflowは、1つでも不足している場合は署名・upload・metadata更新を開始せず終了します。
+
+### App Store Connect
+
+workflowの初回実行前に、App Store Connect側を次の状態にします。
+
+1. `APP_BUNDLE_ID`と一致するiOSアプリを作成する。
+2. App versionを手動公開（Manual release）で扱えるようにする。
+3. 日本語localizationへdescription、keywords、support URLなど審査必須metadataを登録する。
+4. App Review連絡先を登録する。demo accountが必要な場合は名前とパスワードも登録する。
+5. スクリーンショット、年齢区分、プライバシー、価格・配信地域など、workflowが更新しない必須項目を登録する。
+6. `TESTFLIGHT_INTERNAL_GROUP`と完全一致する内部グループを作り、全build自動配布を無効にする。workflowはupload前にこの設定を検証する。
+
+証明書はApple Distribution identityを含むもの、profileは指定Bundle ID・Team IDに一致するApp Store配布用で、期限切れでないものを用意します。Team IDやBundle IDをworkflowへ固定しないでください。
+
+## 共通の入力ルール
+
+Actionsのworkflowを実行するときは、実行branchに`main`を選びます。`commit_sha`は`main`の履歴に含まれる40文字の完全なSHAだけが有効です。短縮SHA、別branchのSHA、存在しないSHAはApple側を変更する前に拒否されます。
+
+App versionは対象commitの`pubspec.yaml`から読み取られる`x.y.z`です。Build numberはworkflowの`github.run_id`で、App Store Connect画面に表示された任意の番号を手入力するものではありません。Flutter SDKは`.fvm/fvm_config.json`の3.44.8を検証し、preflightで`fvm flutter analyze`と`fvm flutter test`を実行します。
+
+## 内部TestFlightで確認してから審査へ提出する
+
+### 1. Deploy TestFlight
+
+1. Actionsで`Deploy TestFlight`を開く。
+2. branchに`main`を選ぶ。
+3. `commit_sha`へ対象commitの完全な40文字SHAを入力して実行する。
+4. SummaryからApp version、Build number、App Store Connect build ID、commit SHA、`Internal distributed: true`を控える。
+5. TestFlightの内部テスターで対象buildを確認する。
+
+Reusable buildは、署名素材を一時keychainへ導入し、profile・Team ID・Bundle ID・期限・用途を検証してからIPAを作成します。Appleのprocessing完了後、指定された内部グループへ対象buildだけを割り当てます。配布ポリシー確認が成功するまでprovenance artifactは保存されません。
+
+配布成功後、`Prepare App Store version` jobがApp Store version枠を準備します。対象versionがすでに存在する場合はManual releaseかつ再利用可能な状態だけを再利用し、live version以下のversionはskipします。
+
+### 2. Submit App Store Review
+
+内部テスターの確認後、Actionsで`Submit App Store Review`を開きます。
+
+- `app_version`: Deploy TestFlight SummaryのApp version
+- `build_number`: 同じSummaryのBuild number（Deploy TestFlightのrun ID）
+- `whats_new_ja`: App Storeに表示する日本語の「このバージョンの新機能」
+- `review_notes`: 必要な場合だけ入力。空欄なら既存値を保持
+
+workflowは成功した`Deploy TestFlight` run、runのbranch、workflow path、commit SHA、90日以内のprovenance artifactを照合します。さらにApp Store Connect側で、同じversion/buildが処理済み・期限内・指定内部グループへ配布済みであること、日本語metadataとReview連絡先が存在すること、別versionの審査競合がないことを確認します。
+
+確認済みbuildを再build・再uploadせず、metadataを更新して`fastlane deliver submit_build`で提出します。`automatic_release: false`のため、Apple承認後に自動公開されることはありません。同じbuildがすでに審査待ち・審査中の場合は、再提出せず`already-submitted`として冪等成功します。
+
+## TestFlightを経由せず審査へ提出する
+
+Actionsで`Build and Submit App Store Review`を開き、branchに`main`を選びます。
+
+- `commit_sha`: 審査対象commitの完全な40文字SHA
+- `whats_new_ja`: App Storeに表示する日本語の「このバージョンの新機能」
+- `review_notes`: 必要な場合だけ入力
+
+共通buildがIPAをuploadした後、どのTestFlightグループにも属さないことをAPIで確認します。submit jobは同一runのprovenance artifact、App version、Build number、build ID、commit SHA、`submission_source: direct_review`、`internal_distributed: false`を照合してから、App Store version準備、metadata更新、審査提出を行います。グループ所属が検出された場合は提出せず停止します。
+
+この経路でも`automatic_release: false`です。uploadしたbuildがApp Store ConnectのTestFlight画面に表示されることはありますが、グループ未所属のため内部テスターへ自動配布されません。
+
+## Summaryとartifactの確認
+
+成功したbuild Summaryには次の値が表示されます。
+
+- App version
+- Build number（run ID）
+- App Store Connect build ID
+- commit SHA
+- submission source（`testflight`または`direct_review`）
+- internal distributed（`true`または`false`）
+
+provenance artifact名は`app-store-build-provenance-<run_id>`です。審査提出時はこのartifactをActions APIから読み取り、期限切れ・重複・内容不一致をfail-closedで拒否します。秘密鍵、証明書、profile、review metadata本文はprovenanceに含めません。
+
+## 失敗時と再実行
+
+| 状況 | 対応 |
+| --- | --- |
+| EnvironmentのVariable/Secret不足 | 値の存在だけを確認してから、同じ入力で再実行する。値をログへ貼り付けない。 |
+| commit SHAが40文字でない、またはmainの祖先でない | `main`上の完全なSHAを入力し直す。Apple側は変更されない。 |
+| Flutter version、pubspec version、Xcode/iOS SDKが契約外 | 対象commitとrunnerの設定を直して再実行する。署名・uploadは開始されない。 |
+| 証明書identity、profileのTeam ID/Bundle ID/用途/期限が不一致 | Apple Developer側で素材を作り直し、同じworkflowを再実行する。 |
+| 内部グループが外部または自動配布 | 自動配布を無効にした内部グループを作り、`TESTFLIGHT_INTERNAL_GROUP`を更新する。 |
+| Buildが未処理、期限切れ、別version/build | processing完了と入力値を確認する。別buildへの差し替えや審査中versionの変更は自動で行わない。 |
+| provenanceがrun/workflow/path/source/buildと一致しない | Summaryとartifactを確認し、取り違えたBuild numberを使わない。 |
+| 審査直行buildがTestFlightグループに所属 | 提出せず停止する。グループ状態を直し、新しいbuildでやり直す。 |
+| 同じbuildがすでに審査待ち・審査中 | `already-submitted`の冪等成功。再提出やmetadataの不要な変更をしない。 |
+| 一時keychainやAPI keyのcleanup | 成否にかかわらずcleanup jobが実行される。失敗時はrunner上の一時ファイルが残っていないことを確認する。 |
+
+進行中のbuild・審査提出はconcurrencyで直列化され、新しい実行が進行中の実行をcancelしません。判断できない状態ではActions SummaryとApp Store Connectの読み取り状態を確認し、Apple側の取り下げや別buildへの差し替えを自動で行わないでください。
+
+## Apple承認後の公開
+
+審査が承認され、対象version/buildが正しいことをApp Store Connectで確認した後、App Store Connectの公開操作を手動で行います。GitHub Actionsには承認後の公開workflowを追加していません。公開の判断、価格・配信地域、公開日時はApple側で確認してから確定します。
+
+## 認証情報登録後の初回確認
+
+1. `testflight` EnvironmentへVariables/Secretsを登録する。
+2. 自動配布を無効にした内部グループを作成する。
+3. `Deploy TestFlight`を`main`の対象SHAで実行する。
+4. Summaryのversion/build/build ID/commit SHAと内部配布状態を確認する。
+5. 実機またはTestFlightで対象buildを確認する。
+6. 審査提出の意思を確認してから、同じversion/buildで`Submit App Store Review`を実行する。
+7. 審査直行を使う場合は、`Build and Submit App Store Review`のSummaryで内部配布が`false`であることを確認する。
+8. Apple承認後、対象version/buildを確認してApp Store Connectから手動公開する。
+
+Issue #46の実装では、認証情報未登録のため署名IPAのupload、TestFlight配布、Apple審査提出のlive実行は行っていません。

--- a/script/app-store-review-workflow.test.sh
+++ b/script/app-store-review-workflow.test.sh
@@ -71,6 +71,7 @@ assert_contains "$workflow" '--precheck_include_in_app_purchases false'
 assert_contains "$workflow" '--submit_for_review true'
 assert_contains "$workflow" 'GITHUB_STEP_SUMMARY'
 assert_contains "$workflow" 'if: always()'
+assert_contains "$workflow" 'ref: ${{ github.sha }}'
 assert_not_contains "$workflow" 'flutter build ipa'
 assert_not_contains "$workflow" 'pilot upload'
 assert_not_contains "$workflow" '--ipa '
@@ -98,6 +99,8 @@ ruby -ryaml -e '
   raise "main guard must be evaluated before the job starts" unless job.fetch("if") == expected_if
   raise "wrong GitHub environment" unless job.fetch("environment") == "testflight"
   steps = job.fetch("steps").to_h { |step| [step.fetch("name"), step] }
+  checkout = steps.fetch("Check out main")
+  raise "submission checkout must pin the dispatch SHA" unless checkout.fetch("with").fetch("ref") == "${{ github.sha }}"
   key_step = steps.fetch("Create App Store Connect API key")
   %w[APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY].each do |name|
     raise "#{name} must be step-scoped" unless key_step.fetch("env").key?(name)

--- a/script/app-store-review-workflow.test.sh
+++ b/script/app-store-review-workflow.test.sh
@@ -58,6 +58,9 @@ assert_contains "$workflow" 'app_version == $app_version'
 assert_contains "$workflow" 'build_number == $build_number'
 assert_contains "$workflow" '.submission_source == "testflight"'
 assert_contains "$workflow" '.internal_distributed == true'
+assert_contains "$workflow" '.event == "workflow_dispatch"'
+assert_not_contains "$workflow" '.commit_sha == $head_sha'
+assert_not_contains "$workflow" '--arg head_sha'
 assert_contains "$workflow" '--distribution-mode internal'
 assert_contains "$workflow" 'fastlane deliver submit_build'
 assert_contains "$workflow" '--skip_binary_upload true'
@@ -107,6 +110,38 @@ ruby -ryaml -e '
   commands = steps.values.filter_map { |step| step["run"] }.join("\n")
   raise "workflow must not build an IPA" if commands.include?("flutter build ipa")
   raise "workflow must not upload an IPA" if commands.include?("pilot upload")
+' "$workflow"
+
+ruby -rjson -e '
+  workflow_path = ARGV.fetch(0)
+  older_target = "a" * 40
+  newer_dispatch_head = "b" * 40
+  run = {
+    "id" => 123,
+    "name" => "Deploy TestFlight",
+    "path" => ".github/workflows/deploy-testflight.yml",
+    "event" => "workflow_dispatch",
+    "head_branch" => "main",
+    "conclusion" => "success",
+    "head_sha" => newer_dispatch_head,
+  }
+  provenance = {
+    "run_id" => 123,
+    "repository" => "yuto90/conquest",
+    "workflow_name" => "Deploy TestFlight",
+    "workflow_path" => ".github/workflows/deploy-testflight.yml",
+    "build_workflow_path" => ".github/workflows/build-ios-app-store.yml",
+    "app_version" => "1.0.1",
+    "build_number" => "123",
+    "build_id" => "build-123",
+    "commit_sha" => older_target,
+    "submission_source" => "testflight",
+    "internal_distributed" => true,
+  }
+  raise "fixture must represent an older target commit" unless provenance["commit_sha"] != run["head_sha"]
+  source = File.read(workflow_path)
+  raise "workflow must not bind provenance to dispatch head SHA" if source.include?(".commit_sha == $head_sha")
+  raise "provenance fixture lost its target SHA" unless provenance["commit_sha"].match?(/\A[0-9a-f]{40}\z/)
 ' "$workflow"
 
 ruby -ryaml -e '

--- a/script/app-store-review-workflow.test.sh
+++ b/script/app-store-review-workflow.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/submit-app-store-review.yml"
+deploy_workflow="$repo_root/.github/workflows/deploy-testflight.yml"
+release_script="$repo_root/script/app_store_release.rb"
+
+assert_file_exists() {
+  [[ -f "$1" ]] || {
+    printf 'expected file to exist: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || {
+    printf 'expected %s to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  if grep -Fq -- "$2" "$1"; then
+    printf 'expected %s not to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists "$workflow"
+assert_file_exists "$deploy_workflow"
+assert_file_exists "$release_script"
+
+assert_contains "$deploy_workflow" 'workflow_dispatch:'
+assert_contains "$deploy_workflow" 'commit_sha:'
+assert_contains "$deploy_workflow" 'uses: ./.github/workflows/build-ios-app-store.yml'
+assert_contains "$deploy_workflow" 'distribute_internal: true'
+assert_contains "$deploy_workflow" 'submission_source: testflight'
+assert_contains "$deploy_workflow" 'prepare-app-store-version:'
+assert_contains "$deploy_workflow" 'ruby script/app_store_release.rb prepare'
+assert_not_contains "$deploy_workflow" 'workflow_run:'
+assert_contains "$workflow" 'name: Submit App Store Review'
+assert_contains "$workflow" 'workflow_dispatch:'
+assert_contains "$workflow" 'app_version:'
+assert_contains "$workflow" 'build_number:'
+assert_contains "$workflow" 'whats_new_ja:'
+assert_contains "$workflow" 'review_notes:'
+assert_contains "$workflow" 'contents: read'
+assert_contains "$workflow" 'actions: read'
+assert_contains "$workflow" 'environment: testflight'
+assert_contains "$workflow" 'cancel-in-progress: false'
+assert_contains "$workflow" 'ruby script/app_store_release.rb preflight'
+assert_contains "$workflow" 'ruby script/app_store_release.rb update-metadata'
+assert_contains "$workflow" 'app-store-build-provenance-$BUILD_NUMBER'
+assert_contains "$workflow" 'app_version == $app_version'
+assert_contains "$workflow" 'build_number == $build_number'
+assert_contains "$workflow" '.submission_source == "testflight"'
+assert_contains "$workflow" '.internal_distributed == true'
+assert_contains "$workflow" '--distribution-mode internal'
+assert_contains "$workflow" 'fastlane deliver submit_build'
+assert_contains "$workflow" '--skip_binary_upload true'
+assert_contains "$workflow" '--skip_screenshots true'
+assert_contains "$workflow" '--skip_metadata true'
+assert_contains "$workflow" '--automatic_release false'
+assert_contains "$workflow" '--precheck_include_in_app_purchases false'
+assert_contains "$workflow" '--submit_for_review true'
+assert_contains "$workflow" 'GITHUB_STEP_SUMMARY'
+assert_contains "$workflow" 'if: always()'
+assert_not_contains "$workflow" 'flutter build ipa'
+assert_not_contains "$workflow" 'pilot upload'
+assert_not_contains "$workflow" '--ipa '
+
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  triggers = workflow["on"] || workflow[true]
+  inputs = triggers.fetch("workflow_dispatch").fetch("inputs")
+  %w[app_version build_number whats_new_ja].each do |name|
+    input = inputs.fetch(name)
+    raise "#{name} must be required" unless input.fetch("required") == true
+    raise "#{name} must be a string" unless input.fetch("type") == "string"
+  end
+  notes = inputs.fetch("review_notes")
+  raise "review_notes must be optional" unless notes.fetch("required") == false
+  raise "review_notes must be a string" unless notes.fetch("type") == "string"
+  permissions = workflow.fetch("permissions")
+  raise "contents permission must be read" unless permissions.fetch("contents") == "read"
+  raise "actions permission must be read" unless permissions.fetch("actions") == "read"
+  concurrency = workflow.fetch("concurrency")
+  raise "review submissions must not cancel" unless concurrency.fetch("cancel-in-progress") == false
+  job = workflow.fetch("jobs").fetch("submit")
+  quote = 39.chr
+  expected_if = "${{ github.ref == #{quote}refs/heads/main#{quote} }}"
+  raise "main guard must be evaluated before the job starts" unless job.fetch("if") == expected_if
+  raise "wrong GitHub environment" unless job.fetch("environment") == "testflight"
+  steps = job.fetch("steps").to_h { |step| [step.fetch("name"), step] }
+  key_step = steps.fetch("Create App Store Connect API key")
+  %w[APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY].each do |name|
+    raise "#{name} must be step-scoped" unless key_step.fetch("env").key?(name)
+    raise "#{name} must not be job-scoped" if job.fetch("env", {}).key?(name)
+  end
+  cleanup = steps.fetch("Clean up App Store Connect key")
+  raise "cleanup must always run" unless cleanup.fetch("if") == "always()"
+  summary = steps.fetch("Write App Store review summary")
+  raise "review summary must always run" unless summary.fetch("if") == "always()"
+  commands = steps.values.filter_map { |step| step["run"] }.join("\n")
+  raise "workflow must not build an IPA" if commands.include?("flutter build ipa")
+  raise "workflow must not upload an IPA" if commands.include?("pilot upload")
+' "$workflow"
+
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  triggers = workflow["on"] || workflow[true]
+  input = triggers.fetch("workflow_dispatch").fetch("inputs").fetch("commit_sha")
+  raise "commit_sha must be required" unless input.fetch("required") == true
+  build = workflow.fetch("jobs").fetch("build")
+  raise "wrong reusable workflow" unless build.fetch("uses") == "./.github/workflows/build-ios-app-store.yml"
+  raise "TestFlight must distribute internally" unless build.fetch("with").fetch("distribute_internal") == true
+  raise "wrong submission source" unless build.fetch("with").fetch("submission_source") == "testflight"
+  prepare = workflow.fetch("jobs").fetch("prepare-app-store-version")
+  raise "prepare must wait for build" unless prepare.fetch("needs") == "build"
+' "$deploy_workflow"
+
+printf 'App Store review workflow tests passed\n'

--- a/script/app_store_release.rb
+++ b/script/app_store_release.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "optparse"
+require_relative "lib/app_store_release"
+
+module AppStoreRelease
+  class CLI
+    def initialize(argv, stdout: $stdout, stderr: $stderr)
+      @argv = argv.dup
+      @stdout = stdout
+      @stderr = stderr
+    end
+
+    def run
+      command = @argv.shift
+      commands = %w[prepare preflight update-metadata]
+      raise OptionParser::MissingArgument, "command" unless commands.include?(command)
+
+      options = parse_options(@argv)
+      validate_common!(options)
+      client = Client.new(api_key_path: options.fetch(:api_key_path))
+      service = Service.new(client: client, bundle_id: options.fetch(:bundle_id))
+
+      payload = case command
+                when "prepare"
+                  result = service.prepare_version(target_version: options.fetch(:app_version))
+                  { action: result.action, version_id: result.version_id, message: result.message }
+                when "preflight"
+                  preflight(service, options).to_h
+                when "update-metadata"
+                  result = preflight(service, options)
+                  service.update_submission_metadata(
+                    preflight: result,
+                    whats_new: options.fetch(:whats_new),
+                    review_notes: options[:review_notes],
+                  )
+                  result.to_h.merge(metadata_updated: result.status != :already_submitted)
+                end
+      @stdout.puts(JSON.generate(payload))
+      0
+    rescue OptionParser::ParseError, AppStoreRelease::Error, Errno::ENOENT,
+           JSON::ParserError, KeyError => error
+      @stderr.puts("::error::#{error.message}")
+      1
+    end
+
+    private
+
+    def parse_options(argv)
+      options = {}
+      OptionParser.new do |parser|
+        parser.on("--api-key-path PATH") { |value| options[:api_key_path] = value }
+        parser.on("--bundle-id ID") { |value| options[:bundle_id] = value }
+        parser.on("--app-version VERSION") { |value| options[:app_version] = value }
+        parser.on("--build-number NUMBER") { |value| options[:build_number] = value }
+        parser.on("--internal-group NAME") { |value| options[:internal_group] = value }
+        parser.on("--distribution-mode MODE") { |value| options[:distribution_mode] = value }
+        parser.on("--whats-new TEXT") { |value| options[:whats_new] = value }
+        parser.on("--review-notes TEXT") { |value| options[:review_notes] = value }
+      end.parse!(argv)
+      options
+    end
+
+    def validate_common!(options)
+      %i[api_key_path bundle_id app_version].each do |name|
+        value = options[name]
+        raise OptionParser::MissingArgument, name.to_s.tr("_", "-") unless value&.match?(%r{\S})
+      end
+      return if options.fetch(:app_version).match?(/\A\d+\.\d+\.\d+\z/)
+
+      raise ValidationError, "App version must be numeric x.y.z"
+    end
+
+    def preflight(service, options)
+      %i[build_number whats_new].each do |name|
+        value = options[name]
+        raise OptionParser::MissingArgument, name.to_s.tr("_", "-") unless value&.match?(%r{\S})
+      end
+      distribution_mode = options.fetch(:distribution_mode, "internal")
+      if distribution_mode == "internal" && !options[:internal_group]&.match?(%r{\S})
+        raise OptionParser::MissingArgument, "internal-group"
+      end
+      service.preflight(
+        app_version: options.fetch(:app_version),
+        build_number: options.fetch(:build_number),
+        internal_group: options[:internal_group],
+        distribution_mode: distribution_mode,
+        whats_new: options.fetch(:whats_new),
+        review_notes: options[:review_notes],
+      )
+    end
+  end
+end
+
+exit(AppStoreRelease::CLI.new(ARGV).run) if $PROGRAM_NAME == __FILE__

--- a/script/app_store_release.rb
+++ b/script/app_store_release.rb
@@ -15,11 +15,14 @@ module AppStoreRelease
 
     def run
       command = @argv.shift
-      commands = %w[prepare prepare-check preflight update-metadata]
+      commands = %w[prepare preflight update-metadata]
       raise OptionParser::MissingArgument, "command" unless commands.include?(command)
 
       options = parse_options(@argv)
       validate_common!(options)
+      if options[:prepare_only] && command != "preflight"
+        raise ValidationError, "--prepare-only is only valid with preflight"
+      end
       client = Client.new(api_key_path: options.fetch(:api_key_path))
       service = Service.new(client: client, bundle_id: options.fetch(:bundle_id))
 
@@ -27,11 +30,13 @@ module AppStoreRelease
                 when "prepare"
                   result = service.prepare_version(target_version: options.fetch(:app_version))
                   { action: result.action, version_id: result.version_id, message: result.message }
-                when "prepare-check"
-                  result = service.prepare_check(target_version: options.fetch(:app_version))
-                  { action: result.action, version_id: result.version_id, message: result.message }
                 when "preflight"
-                  preflight(service, options).to_h
+                  if options[:prepare_only]
+                    result = service.prepare_check(target_version: options.fetch(:app_version))
+                    { action: result.action, version_id: result.version_id, message: result.message }
+                  else
+                    preflight(service, options).to_h
+                  end
                 when "update-metadata"
                   result = preflight(service, options)
                   service.update_submission_metadata(
@@ -60,6 +65,7 @@ module AppStoreRelease
         parser.on("--build-number NUMBER") { |value| options[:build_number] = value }
         parser.on("--internal-group NAME") { |value| options[:internal_group] = value }
         parser.on("--distribution-mode MODE") { |value| options[:distribution_mode] = value }
+        parser.on("--prepare-only") { options[:prepare_only] = true }
         parser.on("--whats-new TEXT") { |value| options[:whats_new] = value }
         parser.on("--review-notes TEXT") { |value| options[:review_notes] = value }
       end.parse!(argv)

--- a/script/app_store_release.rb
+++ b/script/app_store_release.rb
@@ -15,7 +15,7 @@ module AppStoreRelease
 
     def run
       command = @argv.shift
-      commands = %w[prepare preflight update-metadata]
+      commands = %w[prepare prepare-check preflight update-metadata]
       raise OptionParser::MissingArgument, "command" unless commands.include?(command)
 
       options = parse_options(@argv)
@@ -26,6 +26,9 @@ module AppStoreRelease
       payload = case command
                 when "prepare"
                   result = service.prepare_version(target_version: options.fetch(:app_version))
+                  { action: result.action, version_id: result.version_id, message: result.message }
+                when "prepare-check"
+                  result = service.prepare_check(target_version: options.fetch(:app_version))
                   { action: result.action, version_id: result.version_id, message: result.message }
                 when "preflight"
                   preflight(service, options).to_h

--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -179,6 +179,31 @@ class AppStoreReleaseTest < Minitest::Test
     )
   end
 
+  def test_prepare_creates_initial_manual_version_when_no_live_version_exists
+    client = FakeClient.new(versions: [], created_requests: [])
+
+    result = service(client).prepare_version(target_version: "1.0.1")
+
+    assert_equal :created, result.action
+    assert_equal(
+      [{ app_id: "app-1", version: "1.0.1", release_type: "MANUAL" }],
+      client.created_requests,
+    )
+  end
+
+  def test_prepare_reuses_existing_manual_version_when_no_live_version_exists
+    client = FakeClient.new(
+      versions: [version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101")],
+      created_requests: [],
+    )
+
+    result = service(client).prepare_version(target_version: "1.0.1")
+
+    assert_equal :reused, result.action
+    assert_equal "version-101", result.version_id
+    assert_empty client.created_requests
+  end
+
   def test_client_creates_manual_app_store_version
     transport = FakeTransport.new(
       response: { "data" => version("1.0.1", "PREPARE_FOR_SUBMISSION") },

--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -179,6 +179,27 @@ class AppStoreReleaseTest < Minitest::Test
     )
   end
 
+  def test_prepare_skips_older_target_before_reading_attached_build
+    client = FakeClient.new(
+      versions: [
+        version("1.0.7", "READY_FOR_DISTRIBUTION", id: "version-live"),
+        version("1.0.6", "DEVELOPER_REJECTED", id: "version-old"),
+      ],
+      created_requests: [],
+    )
+    client.define_singleton_method(:attached_build) do |version_id:|
+      raise "attached build must not be read for an older target" if version_id == "version-old"
+
+      attached
+    end
+
+    result = service(client).prepare_version(target_version: "1.0.6")
+
+    assert_equal :skipped, result.action
+    assert_equal "version-old", result.version_id
+    assert_empty client.created_requests
+  end
+
   def test_prepare_creates_initial_manual_version_when_no_live_version_exists
     client = FakeClient.new(versions: [], created_requests: [])
 
@@ -201,6 +222,50 @@ class AppStoreReleaseTest < Minitest::Test
 
     assert_equal :reused, result.action
     assert_equal "version-101", result.version_id
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_rejects_another_version_under_review_before_mutating
+    client = FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION", id: "version-live"),
+        version("1.0.2", "WAITING_FOR_REVIEW", id: "version-102"),
+      ],
+      created_requests: [],
+    )
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).prepare_version(target_version: "1.0.1")
+    end
+
+    assert_match(/already in review: 1\.0\.2/, error.message)
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_check_accepts_new_version_without_mutating
+    client = FakeClient.new(versions: [], created_requests: [])
+
+    result = service(client).prepare_check(target_version: "1.0.1")
+
+    assert_equal :would_create, result.action
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_rejects_existing_version_with_an_attached_build_before_mutating
+    client = FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION", id: "version-live"),
+        version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101"),
+      ],
+      created_requests: [],
+      attached: { "id" => "build-existing" },
+    )
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).prepare_version(target_version: "1.0.1")
+    end
+
+    assert_match(/already has a build attached/, error.message)
     assert_empty client.created_requests
   end
 

--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -1,0 +1,496 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require_relative "lib/app_store_release"
+
+class AppStoreReleaseTest < Minitest::Test
+  FakeTransport = Struct.new(:response, :requests, keyword_init: true) do
+    def call(method:, path:, query:, body:, token:)
+      requests << { method: method, path: path, query: query, body: body, token: token }
+      response
+    end
+  end
+
+  FakeClient = Struct.new(
+    :versions,
+    :created_requests,
+    :pre_release_version,
+    :build,
+    :beta_groups,
+    :localizations,
+    :review_details,
+    :attached,
+    :mutations,
+    keyword_init: true,
+  ) do
+    def find_app(bundle_id:)
+      raise "unexpected bundle ID" unless bundle_id == "com.conquest.conquest"
+
+      { "id" => "app-1", "attributes" => { "bundleId" => bundle_id } }
+    end
+
+    def app_store_versions(app_id:)
+      raise "unexpected app ID" unless app_id == "app-1"
+
+      versions
+    end
+
+    def create_app_store_version(app_id:, version:, release_type:)
+      created_requests << { app_id: app_id, version: version, release_type: release_type }
+      {
+        "id" => "version-created",
+        "attributes" => {
+          "versionString" => version,
+          "releaseType" => release_type,
+          "appStoreState" => "PREPARE_FOR_SUBMISSION",
+        },
+      }
+    end
+
+    def find_pre_release_version(app_id:, version:)
+      raise "unexpected pre-release lookup" unless app_id == "app-1" && version == "1.0.1"
+
+      pre_release_version
+    end
+
+    def find_build(pre_release_version_id:, build_number:)
+      raise "unexpected build lookup" unless pre_release_version_id == "pre-101" && build_number == "123"
+
+      build
+    end
+
+    def beta_groups_for_build(build_id:)
+      raise "unexpected build ID" unless build_id == "build-123"
+
+      beta_groups
+    end
+
+    def version_localizations(version_id:)
+      raise "unexpected version ID" unless version_id == "version-101"
+
+      localizations
+    end
+
+    def review_detail(version_id:)
+      raise "unexpected version ID" unless version_id == "version-101"
+
+      review_details
+    end
+
+    def attached_build(version_id:)
+      raise "unexpected version ID" unless version_id == "version-101"
+
+      attached
+    end
+
+    def update_localization(localization_id:, whats_new:)
+      mutations << [:localization, localization_id, whats_new]
+    end
+
+    def update_review_detail(review_detail_id:, notes:)
+      mutations << [:review_detail, review_detail_id, notes]
+    end
+
+    def attach_build(version_id:, build_id:)
+      mutations << [:build, version_id, build_id]
+    end
+  end
+
+  def test_compares_numeric_version_components
+    assert_operator AppStoreRelease.compare_versions("1.10.0", "1.9.9"), :>, 0
+  end
+
+  def test_prepare_skips_version_that_is_not_newer_than_live
+    client = FakeClient.new(
+      versions: [version("1.0.0", "READY_FOR_DISTRIBUTION")],
+      created_requests: [],
+    )
+
+    result = service(client).prepare_version(target_version: "1.0.0")
+
+    assert_equal :skipped, result.action
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_reuses_existing_editable_version
+    client = FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION"),
+        version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101"),
+      ],
+      created_requests: [],
+    )
+
+    result = service(client).prepare_version(target_version: "1.0.1")
+
+    assert_equal :reused, result.action
+    assert_equal "version-101", result.version_id
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_reuses_existing_submitted_version_without_mutating_it
+    client = FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION"),
+        version("1.0.1", "WAITING_FOR_REVIEW", id: "version-101"),
+      ],
+      created_requests: [],
+    )
+
+    result = service(client).prepare_version(target_version: "1.0.1")
+
+    assert_equal :reused, result.action
+    assert_equal "version-101", result.version_id
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_rejects_existing_version_that_is_not_manual_release
+    automatic = version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101")
+    automatic["attributes"]["releaseType"] = "AFTER_APPROVAL"
+    client = FakeClient.new(
+      versions: [version("1.0.0", "READY_FOR_DISTRIBUTION"), automatic],
+      created_requests: [],
+    )
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).prepare_version(target_version: "1.0.1")
+    end
+
+    assert_match(/manual release/, error.message)
+    assert_empty client.created_requests
+  end
+
+  def test_prepare_creates_new_manual_version
+    client = FakeClient.new(
+      versions: [version("1.0.0", "READY_FOR_DISTRIBUTION")],
+      created_requests: [],
+    )
+
+    result = service(client).prepare_version(target_version: "1.0.1")
+
+    assert_equal :created, result.action
+    assert_equal "version-created", result.version_id
+    assert_equal(
+      [{ app_id: "app-1", version: "1.0.1", release_type: "MANUAL" }],
+      client.created_requests,
+    )
+  end
+
+  def test_client_creates_manual_app_store_version
+    transport = FakeTransport.new(
+      response: { "data" => version("1.0.1", "PREPARE_FOR_SUBMISSION") },
+      requests: [],
+    )
+    client = AppStoreRelease::Client.new(transport: transport, token: "test-token")
+
+    client.create_app_store_version(app_id: "app-1", version: "1.0.1", release_type: "MANUAL")
+
+    request = transport.requests.fetch(0)
+    assert_equal "POST", request.fetch(:method)
+    assert_equal "/v1/appStoreVersions", request.fetch(:path)
+    assert_equal "MANUAL", request.dig(:body, "data", "attributes", "releaseType")
+    assert_equal "app-1", request.dig(:body, "data", "relationships", "app", "data", "id")
+  end
+
+  def test_client_reads_beta_groups_from_build_include
+    group = {
+      "type" => "betaGroups",
+      "id" => "group-internal",
+      "attributes" => { "name" => "Internal", "isInternalGroup" => true },
+    }
+    transport = FakeTransport.new(
+      response: { "data" => { "type" => "builds", "id" => "build-123" }, "included" => [group] },
+      requests: [],
+    )
+    client = AppStoreRelease::Client.new(transport: transport, token: "test-token")
+
+    assert_equal [group], client.beta_groups_for_build(build_id: "build-123")
+    request = transport.requests.fetch(0)
+    assert_equal "/v1/builds/build-123", request.fetch(:path)
+    assert_equal "betaGroups", request.dig(:query, "include")
+  end
+
+  def test_client_attaches_build_with_patch_relationship_request
+    transport = FakeTransport.new(response: { "data" => nil }, requests: [])
+    client = AppStoreRelease::Client.new(transport: transport, token: "test-token")
+
+    client.attach_build(version_id: "version-101", build_id: "build-123")
+
+    request = transport.requests.fetch(0)
+    assert_equal "PATCH", request.fetch(:method)
+    assert_equal "/v1/appStoreVersions/version-101/relationships/build", request.fetch(:path)
+    assert_equal "builds", request.dig(:body, "data", "type")
+    assert_equal "build-123", request.dig(:body, "data", "id")
+  end
+
+  def test_preflight_accepts_exact_valid_internal_build
+    result = service(release_client).preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      internal_group: "Internal",
+      whats_new: "改善しました",
+    )
+
+    assert_equal :ready, result.status
+    assert_equal "build-123", result.build_id
+    assert_equal "version-101", result.version_id
+    assert_equal "localization-ja", result.localization_id
+  end
+
+  def test_preflight_rejects_expired_build
+    client = release_client
+    client.build["attributes"]["expired"] = true
+
+    error = assert_raises(AppStoreRelease::ValidationError) do
+      service(client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_match(/expired/, error.message)
+  end
+
+  def test_preflight_rejects_build_that_was_not_distributed_internally
+    client = release_client
+    client.beta_groups = []
+
+    error = assert_raises(AppStoreRelease::ValidationError) do
+      service(client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_match(/internal TestFlight group/, error.message)
+  end
+
+  def test_preflight_accepts_direct_review_build_with_no_beta_groups
+    client = release_client
+    client.beta_groups = []
+
+    result = service(client).preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      distribution_mode: "none",
+      whats_new: "改善しました",
+    )
+
+    assert_equal :ready, result.status
+  end
+
+  def test_preflight_rejects_direct_review_build_assigned_to_any_beta_group
+    error = assert_raises(AppStoreRelease::ValidationError) do
+      service(release_client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        distribution_mode: "none",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_match(/must not belong to a TestFlight group/, error.message)
+  end
+
+  def test_preflight_rejects_review_notes_over_four_thousand_bytes
+    error = assert_raises(AppStoreRelease::ValidationError) do
+      service(release_client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+        review_notes: "あ" * 1_334,
+      )
+    end
+
+    assert_match(/4,000 bytes/, error.message)
+  end
+
+  def test_preflight_requires_demo_credentials_when_demo_account_is_required
+    client = release_client
+    client.review_details["attributes"]["demoAccountRequired"] = true
+    client.review_details["attributes"]["demoAccountName"] = ""
+    client.review_details["attributes"]["demoAccountPassword"] = ""
+
+    error = assert_raises(AppStoreRelease::ValidationError) do
+      service(client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_match(/demoAccountName/, error.message)
+  end
+
+  def test_preflight_rejects_different_attached_build
+    client = release_client
+    client.attached = { "id" => "build-other", "attributes" => { "version" => "122" } }
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).preflight(
+        app_version: "1.0.1",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_match(/different build/, error.message)
+  end
+
+  def test_preflight_treats_same_submitted_build_as_idempotent
+    client = release_client
+    client.versions.last["attributes"]["appStoreState"] = "WAITING_FOR_REVIEW"
+    client.attached = client.build
+
+    result = service(client).preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      internal_group: "Internal",
+      whats_new: "改善しました",
+    )
+
+    assert_equal :already_submitted, result.status
+  end
+
+  def test_update_submission_metadata_updates_whats_new_and_attaches_build
+    client = release_client
+    release_service = service(client)
+    preflight = release_service.preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      internal_group: "Internal",
+      whats_new: "改善しました",
+    )
+
+    release_service.update_submission_metadata(
+      preflight: preflight,
+      whats_new: "改善しました",
+      review_notes: "遊び方を確認してください",
+    )
+
+    assert_equal(
+      [
+        [:localization, "localization-ja", "改善しました"],
+        [:review_detail, "review-detail-1", "遊び方を確認してください"],
+        [:build, "version-101", "build-123"],
+      ],
+      client.mutations,
+    )
+  end
+
+  def test_update_submission_metadata_keeps_existing_review_notes_when_blank
+    client = release_client
+    release_service = service(client)
+    preflight = release_service.preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      internal_group: "Internal",
+      whats_new: "改善しました",
+    )
+
+    release_service.update_submission_metadata(
+      preflight: preflight,
+      whats_new: "改善しました",
+      review_notes: "  ",
+    )
+
+    refute client.mutations.any? { |mutation| mutation.first == :review_detail }
+  end
+
+  def test_cli_rejects_non_numeric_version_before_calling_api
+    script = File.expand_path("app_store_release.rb", __dir__)
+    _stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby,
+      script,
+      "prepare",
+      "--app-version",
+      "latest",
+      "--bundle-id",
+      "com.conquest.conquest",
+      "--api-key-path",
+      "/missing/key.json",
+    )
+
+    refute status.success?
+    assert_match(/numeric x\.y\.z/, stderr)
+  end
+
+  private
+
+  def service(client)
+    AppStoreRelease::Service.new(client: client, bundle_id: "com.conquest.conquest")
+  end
+
+  def version(number, state, id: "version-#{number}")
+    {
+      "id" => id,
+      "attributes" => {
+        "versionString" => number,
+        "appStoreState" => state,
+        "releaseType" => "MANUAL",
+      },
+    }
+  end
+
+  def release_client
+    FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION", id: "version-live"),
+        version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101"),
+      ],
+      created_requests: [],
+      pre_release_version: {
+        "id" => "pre-101",
+        "attributes" => { "version" => "1.0.1", "platform" => "IOS" },
+      },
+      build: {
+        "id" => "build-123",
+        "attributes" => {
+          "version" => "123",
+          "processingState" => "VALID",
+          "expired" => false,
+        },
+      },
+      beta_groups: [
+        {
+          "id" => "group-internal",
+          "attributes" => { "name" => "Internal", "isInternalGroup" => true },
+        },
+      ],
+      localizations: [
+        {
+          "id" => "localization-ja",
+          "attributes" => {
+            "locale" => "ja",
+            "description" => "Conquest game",
+            "keywords" => "game,strategy",
+            "supportUrl" => "https://example.com/support",
+          },
+        },
+      ],
+      review_details: {
+        "id" => "review-detail-1",
+        "attributes" => {
+          "contactFirstName" => "Conquest",
+          "contactLastName" => "Team",
+          "contactPhone" => "+81-90-0000-0000",
+          "contactEmail" => "review@example.com",
+          "demoAccountRequired" => false,
+          "notes" => "遊び方を確認してください",
+        },
+      },
+      attached: nil,
+      mutations: [],
+    )
+  end
+end

--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -225,6 +225,21 @@ class AppStoreReleaseTest < Minitest::Test
     assert_empty client.created_requests
   end
 
+  def test_prepare_rejects_attached_target_when_no_live_version_exists
+    client = FakeClient.new(
+      versions: [version("1.0.1", "PREPARE_FOR_SUBMISSION", id: "version-101")],
+      created_requests: [],
+      attached: { "id" => "build-existing" },
+    )
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).prepare_version(target_version: "1.0.1")
+    end
+
+    assert_match(/already has a build attached/, error.message)
+    assert_empty client.created_requests
+  end
+
   def test_prepare_rejects_another_version_under_review_before_mutating
     client = FakeClient.new(
       versions: [

--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -257,6 +257,23 @@ class AppStoreReleaseTest < Minitest::Test
     assert_empty client.created_requests
   end
 
+  def test_prepare_check_rejects_another_editable_version_before_creating
+    client = FakeClient.new(
+      versions: [
+        version("1.0.0", "READY_FOR_DISTRIBUTION", id: "version-live"),
+        version("1.0.2", "PREPARE_FOR_SUBMISSION", id: "version-102"),
+      ],
+      created_requests: [],
+    )
+
+    error = assert_raises(AppStoreRelease::ConflictError) do
+      service(client).prepare_check(target_version: "1.0.1")
+    end
+
+    assert_match(/editable: 1\.0\.2/, error.message)
+    assert_empty client.created_requests
+  end
+
   def test_prepare_check_accepts_new_version_without_mutating
     client = FakeClient.new(versions: [], created_requests: [])
 
@@ -404,18 +421,30 @@ class AppStoreReleaseTest < Minitest::Test
     assert_match(/must not belong to a TestFlight group/, error.message)
   end
 
-  def test_preflight_rejects_review_notes_over_four_thousand_bytes
+  def test_preflight_accepts_multibyte_review_notes_up_to_four_thousand_characters
+    result = service(release_client).preflight(
+      app_version: "1.0.1",
+      build_number: "123",
+      internal_group: "Internal",
+      whats_new: "改善しました",
+      review_notes: "あ" * 4_000,
+    )
+
+    assert_equal :ready, result.status
+  end
+
+  def test_preflight_rejects_review_notes_over_four_thousand_characters
     error = assert_raises(AppStoreRelease::ValidationError) do
       service(release_client).preflight(
         app_version: "1.0.1",
         build_number: "123",
         internal_group: "Internal",
         whats_new: "改善しました",
-        review_notes: "あ" * 1_334,
+        review_notes: "あ" * 4_001,
       )
     end
 
-    assert_match(/4,000 bytes/, error.message)
+    assert_match(/4,000 characters/, error.message)
   end
 
   def test_preflight_requires_demo_credentials_when_demo_account_is_required

--- a/script/configure-ios-signing.rb
+++ b/script/configure-ios-signing.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "xcodeproj"
+
+project_path = ARGV.fetch(0, "ios/Runner.xcodeproj")
+bundle_id = ENV.fetch("APP_BUNDLE_ID")
+team_id = ENV.fetch("APPLE_TEAM_ID")
+profile_name = ENV.fetch("PROFILE_NAME")
+
+raise "APP_BUNDLE_ID must not be empty" if bundle_id.empty?
+raise "APPLE_TEAM_ID must not be empty" if team_id.empty?
+raise "PROFILE_NAME must not be empty" if profile_name.empty?
+
+project = Xcodeproj::Project.open(project_path)
+runner = project.targets.find { |target| target.name == "Runner" }
+raise "Runner target was not found in #{project_path}" unless runner
+
+release = runner.build_configurations.find { |configuration| configuration.name == "Release" }
+raise "Runner Release configuration was not found in #{project_path}" unless release
+
+release.build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = bundle_id
+release.build_settings["DEVELOPMENT_TEAM"] = team_id
+release.build_settings["CODE_SIGN_STYLE"] = "Manual"
+release.build_settings["CODE_SIGN_IDENTITY"] = "Apple Distribution"
+release.build_settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = "Apple Distribution"
+release.build_settings["PROVISIONING_PROFILE_SPECIFIER"] = profile_name
+
+project.save

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -44,6 +44,10 @@ assert_contains "$workflow" 'App Store build ID does not match build provenance'
 assert_contains "$workflow" 'preflight-target:'
 assert_contains "$workflow" '--prepare-only'
 assert_contains "$workflow" 'ruby script/app_store_release.rb preflight --prepare-only'
+assert_contains "$workflow" 'build_allowed:'
+assert_contains "$workflow" "needs.preflight-target.outputs.build_allowed == 'true'"
+assert_contains "$workflow" 'would_create|reused'
+assert_contains "$workflow" 'Unknown target preflight action'
 assert_not_contains "$workflow" 'ruby script/app_store_release.rb prepare-check'
 assert_contains "$workflow" 'Internal TestFlight distribution: \`false\`'
 assert_contains "$workflow" 'if: always()'
@@ -75,20 +79,30 @@ ruby -ryaml -e '
   target_preflight = jobs.fetch("preflight-target")
   raise "target preflight must run on Ubuntu" unless target_preflight.fetch("runs-on") == "ubuntu-24.04"
   raise "target preflight must use testflight environment" unless target_preflight.fetch("environment") == "testflight"
+  outputs = target_preflight.fetch("outputs")
+  raise "target preflight must expose build_allowed" unless outputs.fetch("build_allowed") == "${{ steps.target-state.outputs.build_allowed }}"
   build = jobs.fetch("build")
   raise "target preflight must run before build" unless build.fetch("needs") == "preflight-target"
+  quote = 39.chr
+  build_guard = "needs.preflight-target.outputs.build_allowed == #{quote}true#{quote}"
+  raise "build must require an allowed target action" unless build.fetch("if").include?(build_guard)
   target_commands = target_preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
   raise "target preflight must perform a read-only prepare check" unless target_commands.include?("--prepare-only")
+  raise "target preflight must capture the action" unless target_commands.include?(".action | strings")
+  raise "target preflight must allow only safe actions" unless target_commands.include?("would_create|reused")
+  raise "unknown target actions must fail closed" unless target_commands.include?("Unknown target preflight action") && target_commands.include?("exit 1")
   raise "target preflight must not upload an IPA" if target_commands.include?("pilot upload")
   raise "wrong reusable workflow" unless build.fetch("uses") == "./.github/workflows/build-ios-app-store.yml"
   raise "direct review must not distribute internally" unless build.fetch("with").fetch("distribute_internal") == false
   raise "wrong direct source" unless build.fetch("with").fetch("submission_source") == "direct_review"
   submit = jobs.fetch("submit")
   raise "submit must wait for build" unless submit.fetch("needs") == "build"
+  submit_guard = "needs.build.result == #{quote}success#{quote}"
+  raise "submit must require a successful build" unless submit.fetch("if").include?(submit_guard)
   raise "wrong GitHub environment" unless submit.fetch("environment") == "testflight"
   quote = 39.chr
-  expected_if = "${{ github.ref == #{quote}refs/heads/main#{quote} }}"
-  raise "direct submit must run from main" unless submit.fetch("if") == expected_if
+  expected_if = "${{ needs.build.result == #{quote}success#{quote} && github.ref == #{quote}refs/heads/main#{quote} }}"
+  raise "direct submit must require a successful main build" unless submit.fetch("if") == expected_if
   steps = submit.fetch("steps").to_h { |step| [step.fetch("name"), step] }
   key_step = steps.fetch("Create App Store Connect API key")
   %w[APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY].each do |name|
@@ -100,6 +114,37 @@ ruby -ryaml -e '
   commands = steps.values.filter_map { |step| step["run"] }.join("\n")
   raise "direct workflow must not upload an IPA" if commands.include?("pilot upload")
   raise "direct workflow must use manual release" unless commands.include?("--automatic_release false")
+' "$workflow"
+
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  target_preflight = workflow.fetch("jobs").fetch("preflight-target")
+  build = workflow.fetch("jobs").fetch("build")
+  quote = 39.chr
+  build_guard = "needs.preflight-target.outputs.build_allowed == #{quote}true#{quote}"
+  raise "build guard must reference the target preflight output" unless build.fetch("if").include?(build_guard)
+
+  fixtures = {
+    "equal-live-target" => "skipped",
+    "older-target" => "skipped",
+    "new-target" => "would_create",
+    "existing-editable-target" => "reused",
+    "unknown-action" => "unexpected",
+  }
+  allowed_actions = %w[would_create reused]
+  fixtures.each do |name, action|
+    build_allowed = allowed_actions.include?(action)
+    if %w[equal-live-target older-target].include?(name)
+      raise "#{name} must not start build/upload" if build_allowed
+    elsif %w[new-target existing-editable-target].include?(name)
+      raise "#{name} must start the allowed build path" unless build_allowed
+    else
+      raise "unknown actions must be rejected" if build_allowed
+    end
+  end
+
+  target_commands = target_preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+  raise "unknown action must fail closed" unless target_commands.include?("Unknown target preflight action") && target_commands.include?("exit 1")
 ' "$workflow"
 
 if compgen -G "$repo_root/.github/workflows/release-app-store.yml" >/dev/null; then

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -41,6 +41,8 @@ assert_contains "$workflow" 'fastlane deliver submit_build'
 assert_contains "$workflow" '--automatic_release false'
 assert_contains "$workflow" '--precheck_include_in_app_purchases false'
 assert_contains "$workflow" 'App Store build ID does not match build provenance'
+assert_contains "$workflow" 'preflight-target:'
+assert_contains "$workflow" 'prepare-check'
 assert_contains "$workflow" 'Internal TestFlight distribution: \`false\`'
 assert_contains "$workflow" 'if: always()'
 assert_not_contains "$workflow" 'flutter build ipa'
@@ -68,7 +70,14 @@ ruby -ryaml -e '
   concurrency = workflow.fetch("concurrency")
   raise "direct review must not cancel" unless concurrency.fetch("cancel-in-progress") == false
   jobs = workflow.fetch("jobs")
+  target_preflight = jobs.fetch("preflight-target")
+  raise "target preflight must run on Ubuntu" unless target_preflight.fetch("runs-on") == "ubuntu-24.04"
+  raise "target preflight must use testflight environment" unless target_preflight.fetch("environment") == "testflight"
   build = jobs.fetch("build")
+  raise "target preflight must run before build" unless build.fetch("needs") == "preflight-target"
+  target_commands = target_preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+  raise "target preflight must perform a read-only prepare check" unless target_commands.include?("prepare-check")
+  raise "target preflight must not upload an IPA" if target_commands.include?("pilot upload")
   raise "wrong reusable workflow" unless build.fetch("uses") == "./.github/workflows/build-ios-app-store.yml"
   raise "direct review must not distribute internally" unless build.fetch("with").fetch("distribute_internal") == false
   raise "wrong direct source" unless build.fetch("with").fetch("submission_source") == "direct_review"

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -42,7 +42,9 @@ assert_contains "$workflow" '--automatic_release false'
 assert_contains "$workflow" '--precheck_include_in_app_purchases false'
 assert_contains "$workflow" 'App Store build ID does not match build provenance'
 assert_contains "$workflow" 'preflight-target:'
-assert_contains "$workflow" 'prepare-check'
+assert_contains "$workflow" '--prepare-only'
+assert_contains "$workflow" 'ruby script/app_store_release.rb preflight --prepare-only'
+assert_not_contains "$workflow" 'ruby script/app_store_release.rb prepare-check'
 assert_contains "$workflow" 'Internal TestFlight distribution: \`false\`'
 assert_contains "$workflow" 'if: always()'
 assert_not_contains "$workflow" 'flutter build ipa'
@@ -76,7 +78,7 @@ ruby -ryaml -e '
   build = jobs.fetch("build")
   raise "target preflight must run before build" unless build.fetch("needs") == "preflight-target"
   target_commands = target_preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
-  raise "target preflight must perform a read-only prepare check" unless target_commands.include?("prepare-check")
+  raise "target preflight must perform a read-only prepare check" unless target_commands.include?("--prepare-only")
   raise "target preflight must not upload an IPA" if target_commands.include?("pilot upload")
   raise "wrong reusable workflow" unless build.fetch("uses") == "./.github/workflows/build-ios-app-store.yml"
   raise "direct review must not distribute internally" unless build.fetch("with").fetch("distribute_internal") == false

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/build-submit-app-store-review.yml"
+
+assert_file_exists() {
+  [[ -f "$1" ]] || {
+    printf 'expected file to exist: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || {
+    printf 'expected %s to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  if grep -Fq -- "$2" "$1"; then
+    printf 'expected %s not to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists "$workflow"
+assert_contains "$workflow" 'name: Build and Submit App Store Review'
+assert_contains "$workflow" 'workflow_dispatch:'
+assert_contains "$workflow" 'commit_sha:'
+assert_contains "$workflow" 'whats_new_ja:'
+assert_contains "$workflow" 'review_notes:'
+assert_contains "$workflow" 'uses: ./.github/workflows/build-ios-app-store.yml'
+assert_contains "$workflow" 'distribute_internal: false'
+assert_contains "$workflow" 'submission_source: direct_review'
+assert_contains "$workflow" '--distribution-mode none'
+assert_contains "$workflow" 'fastlane deliver submit_build'
+assert_contains "$workflow" '--automatic_release false'
+assert_contains "$workflow" '--precheck_include_in_app_purchases false'
+assert_contains "$workflow" 'App Store build ID does not match build provenance'
+assert_contains "$workflow" 'Internal TestFlight distribution: \`false\`'
+assert_contains "$workflow" 'if: always()'
+assert_not_contains "$workflow" 'flutter build ipa'
+assert_not_contains "$workflow" 'pilot upload'
+assert_not_contains "$workflow" '--ipa '
+assert_not_contains "$workflow" 'automatic_release true'
+
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  triggers = workflow["on"] || workflow[true]
+  inputs = triggers.fetch("workflow_dispatch").fetch("inputs")
+  commit = inputs.fetch("commit_sha")
+  raise "commit_sha must be required" unless commit.fetch("required") == true
+  raise "commit_sha must be a string" unless commit.fetch("type") == "string"
+  %w[whats_new_ja].each do |name|
+    input = inputs.fetch(name)
+    raise "#{name} must be required" unless input.fetch("required") == true
+    raise "#{name} must be a string" unless input.fetch("type") == "string"
+  end
+  notes = inputs.fetch("review_notes")
+  raise "review_notes must be optional" unless notes.fetch("required") == false
+  raise "review_notes must be a string" unless notes.fetch("type") == "string"
+  permissions = workflow.fetch("permissions")
+  raise "contents permission must be read" unless permissions.fetch("contents") == "read"
+  concurrency = workflow.fetch("concurrency")
+  raise "direct review must not cancel" unless concurrency.fetch("cancel-in-progress") == false
+  jobs = workflow.fetch("jobs")
+  build = jobs.fetch("build")
+  raise "wrong reusable workflow" unless build.fetch("uses") == "./.github/workflows/build-ios-app-store.yml"
+  raise "direct review must not distribute internally" unless build.fetch("with").fetch("distribute_internal") == false
+  raise "wrong direct source" unless build.fetch("with").fetch("submission_source") == "direct_review"
+  submit = jobs.fetch("submit")
+  raise "submit must wait for build" unless submit.fetch("needs") == "build"
+  raise "wrong GitHub environment" unless submit.fetch("environment") == "testflight"
+  quote = 39.chr
+  expected_if = "${{ github.ref == #{quote}refs/heads/main#{quote} }}"
+  raise "direct submit must run from main" unless submit.fetch("if") == expected_if
+  steps = submit.fetch("steps").to_h { |step| [step.fetch("name"), step] }
+  key_step = steps.fetch("Create App Store Connect API key")
+  %w[APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY].each do |name|
+    raise "#{name} must be step-scoped" unless key_step.fetch("env").key?(name)
+    raise "#{name} must not be job-scoped" if submit.fetch("env", {}).key?(name)
+  end
+  cleanup = steps.fetch("Clean up App Store Connect key")
+  raise "cleanup must always run" unless cleanup.fetch("if") == "always()"
+  commands = steps.values.filter_map { |step| step["run"] }.join("\n")
+  raise "direct workflow must not upload an IPA" if commands.include?("pilot upload")
+  raise "direct workflow must use manual release" unless commands.include?("--automatic_release false")
+' "$workflow"
+
+if compgen -G "$repo_root/.github/workflows/release-app-store.yml" >/dev/null; then
+  printf 'unexpected automatic Release App Store workflow\n' >&2
+  exit 1
+fi
+
+printf 'Direct App Store review workflow tests passed\n'

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -143,6 +143,7 @@ printf '%s\n' \
   '  unknown) printf "%s" "{\"action\":\"unexpected\"}" ;;' \
   '  non_string) printf "%s" "{\"action\":123}" ;;' \
   '  missing) printf "%s" "{}" ;;' \
+  '  editable_conflict) printf "%s\n" "Another iOS App Store version is editable" >&2; exit 1 ;;' \
   '  *) printf "unknown fixture: %s\\n" "$TARGET_PREFLIGHT_FIXTURE" >&2; exit 2 ;;' \
   'esac' > "$stub_bin/ruby"
 chmod +x "$stub_bin/ruby"
@@ -197,6 +198,7 @@ run_target_state skipped 0 $'action=skipped\nbuild_allowed=false'
 run_target_state unknown nonzero ''
 run_target_state non_string nonzero ''
 run_target_state missing nonzero ''
+run_target_state editable_conflict nonzero ''
 
 if compgen -G "$repo_root/.github/workflows/release-app-store.yml" >/dev/null; then
   printf 'unexpected automatic Release App Store workflow\n' >&2

--- a/script/direct-app-store-review-workflow.test.sh
+++ b/script/direct-app-store-review-workflow.test.sh
@@ -116,36 +116,87 @@ ruby -ryaml -e '
   raise "direct workflow must use manual release" unless commands.include?("--automatic_release false")
 ' "$workflow"
 
-ruby -ryaml -e '
+target_state_script="$(ruby -ryaml -e '
   workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
-  target_preflight = workflow.fetch("jobs").fetch("preflight-target")
-  build = workflow.fetch("jobs").fetch("build")
-  quote = 39.chr
-  build_guard = "needs.preflight-target.outputs.build_allowed == #{quote}true#{quote}"
-  raise "build guard must reference the target preflight output" unless build.fetch("if").include?(build_guard)
-
-  fixtures = {
-    "equal-live-target" => "skipped",
-    "older-target" => "skipped",
-    "new-target" => "would_create",
-    "existing-editable-target" => "reused",
-    "unknown-action" => "unexpected",
-  }
-  allowed_actions = %w[would_create reused]
-  fixtures.each do |name, action|
-    build_allowed = allowed_actions.include?(action)
-    if %w[equal-live-target older-target].include?(name)
-      raise "#{name} must not start build/upload" if build_allowed
-    elsif %w[new-target existing-editable-target].include?(name)
-      raise "#{name} must start the allowed build path" unless build_allowed
-    else
-      raise "unknown actions must be rejected" if build_allowed
-    end
+  step = workflow.fetch("jobs").fetch("preflight-target").fetch("steps").find do |candidate|
+    candidate["id"] == "target-state"
   end
+  abort "target-state step is missing" unless step
+  print step.fetch("run")
+' "$workflow")"
+[[ -n "$target_state_script" ]] || {
+  printf 'target-state step must contain a run script\n' >&2
+  exit 1
+}
 
-  target_commands = target_preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
-  raise "unknown action must fail closed" unless target_commands.include?("Unknown target preflight action") && target_commands.include?("exit 1")
-' "$workflow"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+stub_bin="$fixture_root/bin"
+mkdir -p "$stub_bin"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'case "$TARGET_PREFLIGHT_FIXTURE" in' \
+  '  would_create) printf "%s" "{\"action\":\"would_create\"}" ;;' \
+  '  reused) printf "%s" "{\"action\":\"reused\"}" ;;' \
+  '  skipped) printf "%s" "{\"action\":\"skipped\"}" ;;' \
+  '  unknown) printf "%s" "{\"action\":\"unexpected\"}" ;;' \
+  '  non_string) printf "%s" "{\"action\":123}" ;;' \
+  '  missing) printf "%s" "{}" ;;' \
+  '  *) printf "unknown fixture: %s\\n" "$TARGET_PREFLIGHT_FIXTURE" >&2; exit 2 ;;' \
+  'esac' > "$stub_bin/ruby"
+chmod +x "$stub_bin/ruby"
+
+run_target_state() {
+  local fixture="$1"
+  local expected_status="$2"
+  local expected_output="$3"
+  local run_dir="$fixture_root/$fixture"
+  local status
+  mkdir -p "$run_dir"
+  : > "$run_dir/output"
+  : > "$run_dir/summary"
+  if TARGET_PREFLIGHT_FIXTURE="$fixture" \
+    RUNNER_TEMP="$run_dir" \
+    APP_BUNDLE_ID="com.example.conquest" \
+    APP_VERSION="1.0.1" \
+    GITHUB_OUTPUT="$run_dir/output" \
+    GITHUB_STEP_SUMMARY="$run_dir/summary" \
+    PATH="$stub_bin:$PATH" \
+    bash -c "$target_state_script" > "$run_dir/stdout" 2> "$run_dir/stderr"; then
+    status=0
+  else
+    status=$?
+  fi
+  if [[ "$expected_status" == "nonzero" ]]; then
+    if [[ "$status" -eq 0 ]]; then
+      printf '%s fixture unexpectedly succeeded\n' "$fixture" >&2
+      cat "$run_dir/stderr" >&2
+      return 1
+    fi
+  elif [[ "$status" -ne "$expected_status" ]]; then
+    printf '%s fixture returned status %s, expected %s\n' "$fixture" "$status" "$expected_status" >&2
+    cat "$run_dir/stderr" >&2
+    return 1
+  fi
+  if [[ "$expected_status" == "0" ]]; then
+    actual_output="$(<"$run_dir/output")"
+    if [[ "$actual_output" != "$expected_output" ]]; then
+      printf '%s fixture output was %q, expected %q\n' "$fixture" "$actual_output" "$expected_output" >&2
+      return 1
+    fi
+  elif grep -Fq 'build_allowed=true' "$run_dir/output"; then
+    printf '%s fixture must not allow a build\n' "$fixture" >&2
+    return 1
+  fi
+}
+
+run_target_state would_create 0 $'action=would_create\nbuild_allowed=true'
+run_target_state reused 0 $'action=reused\nbuild_allowed=true'
+run_target_state skipped 0 $'action=skipped\nbuild_allowed=false'
+run_target_state unknown nonzero ''
+run_target_state non_string nonzero ''
+run_target_state missing nonzero ''
 
 if compgen -G "$repo_root/.github/workflows/release-app-store.yml" >/dev/null; then
   printf 'unexpected automatic Release App Store workflow\n' >&2

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -307,7 +307,7 @@ module AppStoreRelease
       @bundle_id = bundle_id
     end
 
-    def prepare_version(target_version:)
+    def prepare_version(target_version:, mutate: true)
       validate_version!(target_version)
       app = @client.find_app(bundle_id: @bundle_id)
       app_id = app.fetch("id")
@@ -316,12 +316,29 @@ module AppStoreRelease
       live = versions
              .select { |version| LIVE_STATES.include?(version_state(version)) }
              .max_by { |version| Gem::Version.new(version_string(version)) }
+      conflicting = versions.find do |version|
+        version_string(version) != target_version && SUBMITTED_STATES.include?(version_state(version))
+      end
+      if conflicting
+        raise ConflictError,
+              "Another iOS App Store version is already in review: #{version_string(conflicting)}"
+      end
 
       if live.nil? && exact
         return reusable_version_result(exact)
       end
 
       unless live
+        if exact
+          attached = @client.attached_build(version_id: exact.fetch("id"))
+          if attached
+            raise ConflictError, "App Store version already has a build attached"
+          end
+          return reusable_version_result(exact)
+        end
+
+        return Result.new(:would_create, nil, "App Store version would be created") unless mutate
+
         created = @client.create_app_store_version(
           app_id: app_id,
           version: target_version,
@@ -343,8 +360,14 @@ module AppStoreRelease
       end
 
       if exact
+        attached = @client.attached_build(version_id: exact.fetch("id"))
+        if attached
+          raise ConflictError, "App Store version already has a build attached"
+        end
         return reusable_version_result(exact)
       end
+
+      return Result.new(:would_create, nil, "App Store version would be created") unless mutate
 
       created = @client.create_app_store_version(
         app_id: app_id,
@@ -352,6 +375,10 @@ module AppStoreRelease
         release_type: "MANUAL",
       )
       Result.new(:created, created.fetch("id"), "App Store version created")
+    end
+
+    def prepare_check(target_version:)
+      prepare_version(target_version: target_version, mutate: false)
     end
 
     def preflight(

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -316,7 +316,19 @@ module AppStoreRelease
       live = versions
              .select { |version| LIVE_STATES.include?(version_state(version)) }
              .max_by { |version| Gem::Version.new(version_string(version)) }
-      raise ValidationError, "A live App Store version is required for an update" unless live
+
+      if live.nil? && exact
+        return reusable_version_result(exact)
+      end
+
+      unless live
+        created = @client.create_app_store_version(
+          app_id: app_id,
+          version: target_version,
+          release_type: "MANUAL",
+        )
+        return Result.new(:created, created.fetch("id"), "App Store version created")
+      end
 
       if exact && LIVE_STATES.include?(version_state(exact))
         return Result.new(:skipped, exact.fetch("id"), "Target version is already live")
@@ -331,16 +343,7 @@ module AppStoreRelease
       end
 
       if exact
-        release_type = exact.fetch("attributes").fetch("releaseType")
-        unless release_type == "MANUAL"
-          raise ConflictError, "Existing App Store version must use manual release"
-        end
-        state = version_state(exact)
-        unless (EDITABLE_STATES + SUBMITTED_STATES).include?(state)
-          raise ConflictError, "Existing App Store version is not reusable from state #{state}"
-        end
-
-        return Result.new(:reused, exact.fetch("id"), "App Store version already exists")
+        return reusable_version_result(exact)
       end
 
       created = @client.create_app_store_version(
@@ -443,6 +446,19 @@ module AppStoreRelease
     end
 
     private
+
+    def reusable_version_result(version)
+      release_type = version.fetch("attributes").fetch("releaseType")
+      unless release_type == "MANUAL"
+        raise ConflictError, "Existing App Store version must use manual release"
+      end
+      state = version_state(version)
+      unless (EDITABLE_STATES + SUBMITTED_STATES).include?(state)
+        raise ConflictError, "Existing App Store version is not reusable from state #{state}"
+      end
+
+      Result.new(:reused, version.fetch("id"), "App Store version already exists")
+    end
 
     def validate_version!(value)
       return if value&.match?(/\A\d+\.\d+\.\d+\z/)

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -316,12 +316,32 @@ module AppStoreRelease
       live = versions
              .select { |version| LIVE_STATES.include?(version_state(version)) }
              .max_by { |version| Gem::Version.new(version_string(version)) }
-      conflicting = versions.find do |version|
+      submitted_conflicting = versions.find do |version|
         version_string(version) != target_version && SUBMITTED_STATES.include?(version_state(version))
       end
-      if conflicting
+      if submitted_conflicting
         raise ConflictError,
-              "Another iOS App Store version is already in review: #{version_string(conflicting)}"
+              "Another iOS App Store version is already in review: #{version_string(submitted_conflicting)}"
+      end
+
+      if exact && LIVE_STATES.include?(version_state(exact))
+        return Result.new(:skipped, exact.fetch("id"), "Target version is already live")
+      end
+
+      if live && AppStoreRelease.compare_versions(target_version, version_string(live)) <= 0
+        return Result.new(
+          :skipped,
+          exact&.fetch("id"),
+          "Target version is not newer than the live App Store version",
+        )
+      end
+
+      editable_conflicting = versions.find do |version|
+        version_string(version) != target_version && EDITABLE_STATES.include?(version_state(version))
+      end
+      if editable_conflicting
+        raise ConflictError,
+              "Another iOS App Store version is editable: #{version_string(editable_conflicting)}"
       end
 
       unless live
@@ -341,18 +361,6 @@ module AppStoreRelease
           release_type: "MANUAL",
         )
         return Result.new(:created, created.fetch("id"), "App Store version created")
-      end
-
-      if exact && LIVE_STATES.include?(version_state(exact))
-        return Result.new(:skipped, exact.fetch("id"), "Target version is already live")
-      end
-
-      if AppStoreRelease.compare_versions(target_version, version_string(live)) <= 0
-        return Result.new(
-          :skipped,
-          exact&.fetch("id"),
-          "Target version is not newer than the live App Store version",
-        )
       end
 
       if exact
@@ -502,9 +510,9 @@ module AppStoreRelease
 
     def validate_review_notes!(value)
       return unless value&.match?(%r{\S})
-      return if value.bytesize <= 4_000
+      return if value.length <= 4_000
 
-      raise ValidationError, "App Review notes must be 4,000 bytes or fewer"
+      raise ValidationError, "App Review notes must be 4,000 characters or fewer"
     end
 
     def validate_build!(build)

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -1,0 +1,544 @@
+# frozen_string_literal: true
+
+require "rubygems/version"
+require "json"
+require "net/http"
+require "openssl"
+require "uri"
+
+module AppStoreRelease
+  class Error < StandardError; end
+  class ValidationError < Error; end
+  class ConflictError < Error; end
+
+  Result = Struct.new(:action, :version_id, :message)
+  PreflightResult = Struct.new(
+    :status,
+    :app_id,
+    :version_id,
+    :build_id,
+    :localization_id,
+    :review_detail_id,
+    :attached_build_id,
+    keyword_init: true,
+  )
+
+  EDITABLE_STATES = %w[
+    PREPARE_FOR_SUBMISSION
+    READY_FOR_REVIEW
+    DEVELOPER_REJECTED
+    METADATA_REJECTED
+    REJECTED
+  ].freeze
+  LIVE_STATES = %w[READY_FOR_DISTRIBUTION READY_FOR_SALE].freeze
+  SUBMITTED_STATES = %w[
+    WAITING_FOR_REVIEW
+    IN_REVIEW
+    PENDING_DEVELOPER_RELEASE
+    PENDING_APPLE_RELEASE
+  ].freeze
+
+  class NetHttpTransport
+    def initialize(base_url: "https://api.appstoreconnect.apple.com")
+      @base_url = base_url
+    end
+
+    def call(method:, path:, query:, body:, token:)
+      uri = URI.join(@base_url, path)
+      uri.query = URI.encode_www_form(query) unless query.empty?
+      request = request_class(method).new(uri)
+      request["Authorization"] = "Bearer #{token}"
+      request["Accept"] = "application/json"
+      if body
+        request["Content-Type"] = "application/json"
+        request.body = JSON.generate(body)
+      end
+
+      response = Net::HTTP.start(
+        uri.hostname,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+      ) { |http| http.request(request) }
+      parsed = response.body.to_s.empty? ? {} : JSON.parse(response.body)
+      return parsed if response.is_a?(Net::HTTPSuccess)
+
+      details = Array(parsed["errors"]).filter_map do |error|
+        error["detail"] || error["title"]
+      end
+      message = details.empty? ? response.message : details.join("; ")
+      raise Error, "App Store Connect API #{response.code}: #{message}"
+    rescue JSON::ParserError
+      raise Error, "App Store Connect API returned invalid JSON"
+    end
+
+    private
+
+    def request_class(method)
+      {
+        "GET" => Net::HTTP::Get,
+        "POST" => Net::HTTP::Post,
+        "PATCH" => Net::HTTP::Patch,
+      }.fetch(method)
+    end
+  end
+
+  class TokenProvider
+    def initialize(api_key_path:, now: -> { Time.now.to_i })
+      @config = JSON.parse(File.read(api_key_path))
+      @now = now
+    end
+
+    def token
+      require "jwt"
+      issued_at = @now.call
+      private_key = OpenSSL::PKey::EC.new(@config.fetch("key"))
+      JWT.encode(
+        {
+          iss: @config.fetch("issuer_id"),
+          iat: issued_at,
+          exp: issued_at + 1_200,
+          aud: "appstoreconnect-v1",
+        },
+        private_key,
+        "ES256",
+        { kid: @config.fetch("key_id") },
+      )
+    end
+  end
+
+  class Client
+    def initialize(transport: NetHttpTransport.new, token: nil, api_key_path: nil)
+      @transport = transport
+      @token = token
+      @token_provider = TokenProvider.new(api_key_path: api_key_path) if api_key_path
+      raise ArgumentError, "token or api_key_path is required" unless @token || @token_provider
+    end
+
+    def find_app(bundle_id:)
+      matches = get(
+        "/v1/apps",
+        query: { "filter[bundleId]" => bundle_id, "limit" => "2" },
+      ).fetch("data").select do |app|
+        app.fetch("attributes").fetch("bundleId") == bundle_id
+      end
+      require_exactly_one(matches, "App Store Connect app for #{bundle_id}")
+    end
+
+    def app_store_versions(app_id:)
+      get(
+        "/v1/apps/#{app_id}/appStoreVersions",
+        query: { "filter[platform]" => "IOS", "limit" => "200" },
+      ).fetch("data")
+    end
+
+    def create_app_store_version(app_id:, version:, release_type:)
+      post(
+        "/v1/appStoreVersions",
+        body: {
+          "data" => {
+            "type" => "appStoreVersions",
+            "attributes" => {
+              "platform" => "IOS",
+              "versionString" => version,
+              "releaseType" => release_type,
+            },
+            "relationships" => {
+              "app" => { "data" => { "type" => "apps", "id" => app_id } },
+            },
+          },
+        },
+      ).fetch("data")
+    end
+
+    def find_pre_release_version(app_id:, version:)
+      matches = get(
+        "/v1/preReleaseVersions",
+        query: {
+          "filter[app]" => app_id,
+          "filter[version]" => version,
+          "filter[platform]" => "IOS",
+          "limit" => "2",
+        },
+      ).fetch("data").select do |candidate|
+        attributes = candidate.fetch("attributes")
+        attributes.fetch("version") == version && attributes.fetch("platform") == "IOS"
+      end
+      require_exactly_one(matches, "iOS pre-release version #{version}")
+    end
+
+    def find_build(pre_release_version_id:, build_number:)
+      matches = get(
+        "/v1/builds",
+        query: {
+          "filter[preReleaseVersion]" => pre_release_version_id,
+          "filter[version]" => build_number,
+          "limit" => "2",
+        },
+      ).fetch("data").select do |build|
+        build.fetch("attributes").fetch("version") == build_number
+      end
+      require_exactly_one(matches, "build #{build_number}")
+    end
+
+    def beta_groups_for_build(build_id:)
+      response = get(
+        "/v1/builds/#{build_id}",
+        query: {
+          "include" => "betaGroups",
+          "fields[betaGroups]" => "name,isInternalGroup",
+          "limit[betaGroups]" => "50",
+        },
+      )
+      Array(response["included"]).select { |resource| resource["type"] == "betaGroups" }
+    end
+
+    def find_beta_group(app_id:, name:)
+      matches = get(
+        "/v1/betaGroups",
+        query: {
+          "filter[app]" => app_id,
+          "filter[name]" => name,
+          "fields[betaGroups]" => "name,isInternalGroup,hasAccessToAllBuilds",
+          "limit" => "2",
+        },
+      ).fetch("data").select do |group|
+        group.fetch("attributes").fetch("name") == name
+      end
+      require_exactly_one(matches, "TestFlight beta group named #{name}")
+    end
+
+    def add_build_to_beta_group(group_id:, build_id:)
+      post(
+        "/v1/betaGroups/#{group_id}/relationships/builds",
+        body: { "data" => [{ "type" => "builds", "id" => build_id }] },
+      )
+    end
+
+    def version_localizations(version_id:)
+      get(
+        "/v1/appStoreVersions/#{version_id}/appStoreVersionLocalizations",
+        query: { "limit" => "200" },
+      ).fetch("data")
+    end
+
+    def review_detail(version_id:)
+      get("/v1/appStoreVersions/#{version_id}/appStoreReviewDetail").fetch("data")
+    rescue KeyError
+      nil
+    end
+
+    def attached_build(version_id:)
+      get("/v1/appStoreVersions/#{version_id}/relationships/build")["data"]
+    end
+
+    def update_localization(localization_id:, whats_new:)
+      patch(
+        "/v1/appStoreVersionLocalizations/#{localization_id}",
+        body: {
+          "data" => {
+            "type" => "appStoreVersionLocalizations",
+            "id" => localization_id,
+            "attributes" => { "whatsNew" => whats_new },
+          },
+        },
+      )
+    end
+
+    def update_review_detail(review_detail_id:, notes:)
+      patch(
+        "/v1/appStoreReviewDetails/#{review_detail_id}",
+        body: {
+          "data" => {
+            "type" => "appStoreReviewDetails",
+            "id" => review_detail_id,
+            "attributes" => { "notes" => notes },
+          },
+        },
+      )
+    end
+
+    def attach_build(version_id:, build_id:)
+      patch(
+        "/v1/appStoreVersions/#{version_id}/relationships/build",
+        body: { "data" => { "type" => "builds", "id" => build_id } },
+      )
+    end
+
+    private
+
+    def get(path, query: {})
+      request("GET", path, query: query)
+    end
+
+    def post(path, body:)
+      request("POST", path, body: body)
+    end
+
+    def patch(path, body:)
+      request("PATCH", path, body: body)
+    end
+
+    def request(method, path, query: {}, body: nil)
+      @transport.call(
+        method: method,
+        path: path,
+        query: query,
+        body: body,
+        token: @token || @token_provider.token,
+      )
+    end
+
+    def require_exactly_one(matches, label)
+      return matches.first if matches.length == 1
+
+      raise ValidationError, "Expected exactly one #{label}, found #{matches.length}"
+    end
+  end
+
+  def self.compare_versions(left, right)
+    Gem::Version.new(left) <=> Gem::Version.new(right)
+  rescue ArgumentError
+    raise ValidationError, "App version must be numeric x.y.z"
+  end
+
+  class Service
+    def initialize(client:, bundle_id:)
+      @client = client
+      @bundle_id = bundle_id
+    end
+
+    def prepare_version(target_version:)
+      validate_version!(target_version)
+      app = @client.find_app(bundle_id: @bundle_id)
+      app_id = app.fetch("id")
+      versions = @client.app_store_versions(app_id: app_id)
+      exact = versions.find { |version| version_string(version) == target_version }
+      live = versions
+             .select { |version| LIVE_STATES.include?(version_state(version)) }
+             .max_by { |version| Gem::Version.new(version_string(version)) }
+      raise ValidationError, "A live App Store version is required for an update" unless live
+
+      if exact && LIVE_STATES.include?(version_state(exact))
+        return Result.new(:skipped, exact.fetch("id"), "Target version is already live")
+      end
+
+      if AppStoreRelease.compare_versions(target_version, version_string(live)) <= 0
+        return Result.new(
+          :skipped,
+          exact&.fetch("id"),
+          "Target version is not newer than the live App Store version",
+        )
+      end
+
+      if exact
+        release_type = exact.fetch("attributes").fetch("releaseType")
+        unless release_type == "MANUAL"
+          raise ConflictError, "Existing App Store version must use manual release"
+        end
+        state = version_state(exact)
+        unless (EDITABLE_STATES + SUBMITTED_STATES).include?(state)
+          raise ConflictError, "Existing App Store version is not reusable from state #{state}"
+        end
+
+        return Result.new(:reused, exact.fetch("id"), "App Store version already exists")
+      end
+
+      created = @client.create_app_store_version(
+        app_id: app_id,
+        version: target_version,
+        release_type: "MANUAL",
+      )
+      Result.new(:created, created.fetch("id"), "App Store version created")
+    end
+
+    def preflight(
+      app_version:,
+      build_number:,
+      whats_new:,
+      internal_group: nil,
+      distribution_mode: "internal",
+      review_notes: nil
+    )
+      validate_version!(app_version)
+      validate_build_number!(build_number)
+      validate_required_text!(whats_new, "Japanese what's new")
+      validate_review_notes!(review_notes)
+
+      app = @client.find_app(bundle_id: @bundle_id)
+      app_id = app.fetch("id")
+      versions = @client.app_store_versions(app_id: app_id)
+      version = versions.find { |candidate| version_string(candidate) == app_version }
+      raise ValidationError, "App Store version #{app_version} was not found" unless version
+
+      state = version_state(version)
+      unless (EDITABLE_STATES + SUBMITTED_STATES).include?(state)
+        raise ValidationError, "App Store version #{app_version} is not reviewable from state #{state}"
+      end
+      release_type = version.fetch("attributes").fetch("releaseType")
+      raise ValidationError, "App Store version must use manual release" unless release_type == "MANUAL"
+
+      conflicting = versions.find do |candidate|
+        version_string(candidate) != app_version && SUBMITTED_STATES.include?(version_state(candidate))
+      end
+      if conflicting
+        raise ConflictError,
+              "Another iOS App Store version is already in review: #{version_string(conflicting)}"
+      end
+
+      pre_release = @client.find_pre_release_version(app_id: app_id, version: app_version)
+      build = @client.find_build(
+        pre_release_version_id: pre_release.fetch("id"),
+        build_number: build_number,
+      )
+      validate_build!(build)
+      validate_distribution!(
+        build.fetch("id"),
+        mode: distribution_mode,
+        internal_group: internal_group,
+      )
+
+      version_id = version.fetch("id")
+      localization = japanese_localization!(version_id)
+      review_detail = @client.review_detail(version_id: version_id)
+      validate_review_detail!(review_detail)
+      attached = @client.attached_build(version_id: version_id)
+      if attached && attached.fetch("id") != build.fetch("id")
+        raise ConflictError, "App Store version has a different build attached"
+      end
+
+      status = SUBMITTED_STATES.include?(state) ? :already_submitted : :ready
+      if status == :already_submitted && !attached
+        raise ConflictError, "Submitted App Store version has no attached build"
+      end
+
+      PreflightResult.new(
+        status: status,
+        app_id: app_id,
+        version_id: version_id,
+        build_id: build.fetch("id"),
+        localization_id: localization.fetch("id"),
+        review_detail_id: review_detail.fetch("id"),
+        attached_build_id: attached&.fetch("id"),
+      )
+    end
+
+    def update_submission_metadata(preflight:, whats_new:, review_notes: nil)
+      return if preflight.status == :already_submitted
+
+      validate_required_text!(whats_new, "Japanese what's new")
+      validate_review_notes!(review_notes)
+      @client.update_localization(
+        localization_id: preflight.localization_id,
+        whats_new: whats_new,
+      )
+      if review_notes&.match?(%r{\S})
+        @client.update_review_detail(
+          review_detail_id: preflight.review_detail_id,
+          notes: review_notes,
+        )
+      end
+      return if preflight.attached_build_id == preflight.build_id
+
+      @client.attach_build(version_id: preflight.version_id, build_id: preflight.build_id)
+    end
+
+    private
+
+    def validate_version!(value)
+      return if value&.match?(/\A\d+\.\d+\.\d+\z/)
+
+      raise ValidationError, "App version must be numeric x.y.z"
+    end
+
+    def validate_build_number!(value)
+      return if value&.match?(/\A\d+\z/)
+
+      raise ValidationError, "Build number must contain digits only"
+    end
+
+    def validate_required_text!(value, label)
+      raise ValidationError, "#{label} must not be blank" unless value&.match?(%r{\S})
+      raise ValidationError, "#{label} must be 4,000 characters or fewer" if value.length > 4_000
+    end
+
+    def validate_review_notes!(value)
+      return unless value&.match?(%r{\S})
+      return if value.bytesize <= 4_000
+
+      raise ValidationError, "App Review notes must be 4,000 bytes or fewer"
+    end
+
+    def validate_build!(build)
+      attributes = build.fetch("attributes")
+      state = attributes.fetch("processingState")
+      raise ValidationError, "Build processing state is #{state}, expected VALID" unless state == "VALID"
+      raise ValidationError, "Build is expired" if attributes.fetch("expired")
+    end
+
+    def validate_distribution!(build_id, mode:, internal_group:)
+      groups = @client.beta_groups_for_build(build_id: build_id)
+      if mode == "none"
+        return if groups.empty?
+
+        raise ValidationError, "Direct-review build must not belong to a TestFlight group"
+      end
+      unless mode == "internal"
+        raise ValidationError, "Distribution mode must be internal or none"
+      end
+      validate_required_text!(internal_group, "Internal TestFlight group")
+
+      matching = groups.select do |group|
+        attributes = group.fetch("attributes")
+        attributes.fetch("name") == internal_group && attributes.fetch("isInternalGroup") == true
+      end
+      return if matching.length == 1
+
+      raise ValidationError,
+            "Build must belong to exactly one internal TestFlight group named #{internal_group}"
+    end
+
+    def japanese_localization!(version_id)
+      localizations = @client.version_localizations(version_id: version_id)
+      japanese = localizations.find do |localization|
+        %w[ja ja-JP].include?(localization.fetch("attributes").fetch("locale"))
+      end
+      raise ValidationError, "Japanese App Store localization was not found" unless japanese
+
+      attributes = japanese.fetch("attributes")
+      %w[description keywords supportUrl].each do |name|
+        value = attributes[name]
+        raise ValidationError, "Japanese localization #{name} must not be blank" unless value&.match?(%r{\S})
+      end
+      japanese
+    end
+
+    def validate_review_detail!(review_detail)
+      raise ValidationError, "App Review details were not found" unless review_detail
+
+      attributes = review_detail.fetch("attributes")
+      %w[contactFirstName contactLastName contactPhone contactEmail].each do |name|
+        value = attributes[name]
+        raise ValidationError, "App Review detail #{name} must not be blank" unless value&.match?(%r{\S})
+      end
+      demo_required = attributes["demoAccountRequired"]
+      unless [true, false].include?(demo_required)
+        raise ValidationError, "App Review detail demoAccountRequired must be true or false"
+      end
+      return unless demo_required
+
+      %w[demoAccountName demoAccountPassword].each do |name|
+        value = attributes[name]
+        raise ValidationError, "App Review detail #{name} must not be blank" unless value&.match?(%r{\S})
+      end
+    end
+
+    def version_string(version)
+      version.fetch("attributes").fetch("versionString")
+    end
+
+    def version_state(version)
+      attributes = version.fetch("attributes")
+      attributes["appVersionState"] || attributes.fetch("appStoreState")
+    end
+  end
+end

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -324,10 +324,6 @@ module AppStoreRelease
               "Another iOS App Store version is already in review: #{version_string(conflicting)}"
       end
 
-      if live.nil? && exact
-        return reusable_version_result(exact)
-      end
-
       unless live
         if exact
           attached = @client.attached_build(version_id: exact.fetch("id"))

--- a/script/testflight-internal-group.rb
+++ b/script/testflight-internal-group.rb
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "lib/app_store_release"
+
+module TestFlightInternalGroup
+  POLL_INTERVAL_SECONDS = 15
+
+  class CLI
+    def initialize(
+      argv,
+      stdout: $stdout,
+      stderr: $stderr,
+      sleep_fn: ->(seconds) { sleep(seconds) },
+      client_factory: ->(path) { AppStoreRelease::Client.new(api_key_path: path) }
+    )
+      @argv = argv.dup
+      @stdout = stdout
+      @stderr = stderr
+      @sleep_fn = sleep_fn
+      @client_factory = client_factory
+    end
+
+    def run
+      command = @argv.shift
+      unless %w[validate-manual assign-build assert-no-groups].include?(command)
+        raise AppStoreRelease::ValidationError, usage
+      end
+
+      api_key_path = required_argument!("API_KEY_PATH")
+      bundle_id = required_argument!("BUNDLE_ID")
+      group_name = required_argument!("GROUP_NAME")
+      client = @client_factory.call(api_key_path)
+      app = client.find_app(bundle_id: bundle_id)
+      group = validate_manual_group!(client, app.fetch("id"), group_name)
+
+      if command == "validate-manual"
+        @stdout.puts(JSON.generate(status: "manual", group_id: group.fetch("id")))
+        return 0
+      end
+
+      app_version = required_argument!("APP_VERSION")
+      build_number = required_argument!("BUILD_NUMBER")
+      timeout_seconds = positive_integer!(@argv.shift || "300", "TIMEOUT_SECONDS")
+      build = wait_for_build(
+        client,
+        app_id: app.fetch("id"),
+        app_version: app_version,
+        build_number: build_number,
+        timeout_seconds: timeout_seconds,
+      )
+
+      case command
+      when "assign-build"
+        current_groups = client.beta_groups_for_build(build_id: build.fetch("id"))
+        unless current_groups.any? { |candidate| candidate.fetch("id") == group.fetch("id") }
+          client.add_build_to_beta_group(group_id: group.fetch("id"), build_id: build.fetch("id"))
+        end
+        wait_for_internal_assignment(
+          client,
+          build_id: build.fetch("id"),
+          group_id: group.fetch("id"),
+          timeout_seconds: timeout_seconds,
+        )
+        @stdout.puts(JSON.generate(status: "assigned", build_id: build.fetch("id")))
+      when "assert-no-groups"
+        groups = client.beta_groups_for_build(build_id: build.fetch("id"))
+        unless groups.empty?
+          names = groups.map { |candidate| candidate.dig("attributes", "name") }.compact
+          raise AppStoreRelease::ValidationError,
+                "Direct-review build must not belong to a TestFlight group: #{names.join(', ')}"
+        end
+        @stdout.puts(JSON.generate(status: "unassigned", build_id: build.fetch("id")))
+      end
+      0
+    rescue AppStoreRelease::Error, ArgumentError, Errno::ENOENT,
+           JSON::ParserError, KeyError => error
+      @stderr.puts("::error::#{error.message}")
+      1
+    end
+
+    private
+
+    def validate_manual_group!(client, app_id, group_name)
+      group = client.find_beta_group(app_id: app_id, name: group_name)
+      attributes = group.fetch("attributes")
+      unless attributes.fetch("isInternalGroup") == true
+        raise AppStoreRelease::ValidationError,
+              "TestFlight group is not internal: #{group_name}"
+      end
+      if attributes.fetch("hasAccessToAllBuilds") == true
+        raise AppStoreRelease::ValidationError,
+              "Disable automatic distribution for the internal TestFlight group: #{group_name}"
+      end
+      group
+    end
+
+    def wait_for_build(client, app_id:, app_version:, build_number:, timeout_seconds:)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+      loop do
+        begin
+          pre_release = client.find_pre_release_version(app_id: app_id, version: app_version)
+          build = client.find_build(
+            pre_release_version_id: pre_release.fetch("id"),
+            build_number: build_number,
+          )
+          attributes = build.fetch("attributes")
+          state = attributes.fetch("processingState")
+          if state == "VALID" && attributes.fetch("expired") == false
+            return build
+          end
+          raise AppStoreRelease::ValidationError,
+                "Build processing state is #{state}, expected VALID"
+        rescue AppStoreRelease::ValidationError => error
+          raise error if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+          @sleep_fn.call(POLL_INTERVAL_SECONDS)
+        end
+      end
+    end
+
+    def wait_for_internal_assignment(client, build_id:, group_id:, timeout_seconds:)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+      loop do
+        groups = client.beta_groups_for_build(build_id: build_id)
+        return if groups.any? { |candidate| candidate.fetch("id") == group_id }
+
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+          raise AppStoreRelease::ValidationError,
+                "Timed out waiting for the build to join the internal TestFlight group"
+        end
+        @sleep_fn.call(POLL_INTERVAL_SECONDS)
+      end
+    end
+
+    def required_argument!(name)
+      value = @argv.shift
+      return value if value&.match?(%r{\S})
+
+      raise AppStoreRelease::ValidationError, "#{name} is required; #{usage}"
+    end
+
+    def positive_integer!(value, name)
+      parsed = Integer(value, 10)
+      return parsed if parsed.positive?
+
+      raise ArgumentError, "#{name} must be a positive integer"
+    rescue ArgumentError
+      raise AppStoreRelease::ValidationError, "#{name} must be a positive integer"
+    end
+
+    def usage
+      "Usage: #{$PROGRAM_NAME} <validate-manual|assign-build|assert-no-groups> " \
+        "API_KEY_PATH BUNDLE_ID GROUP_NAME [APP_VERSION BUILD_NUMBER TIMEOUT_SECONDS]"
+    end
+  end
+end
+
+exit(TestFlightInternalGroup::CLI.new(ARGV).run) if $PROGRAM_NAME == __FILE__

--- a/script/testflight-workflows.test.sh
+++ b/script/testflight-workflows.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_workflow="$repo_root/.github/workflows/build-ios-app-store.yml"
+signing_script="$repo_root/script/configure-ios-signing.rb"
+internal_group_script="$repo_root/script/testflight-internal-group.rb"
+fvm_config="$repo_root/.fvm/fvm_config.json"
+
+assert_file_exists() {
+  [[ -f "$1" ]] || {
+    printf 'expected file to exist: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+assert_contains() {
+  grep -Fq -- "$2" "$1" || {
+    printf 'expected %s to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  if grep -Fq -- "$2" "$1"; then
+    printf 'expected %s not to contain: %s\n' "$1" "$2" >&2
+    exit 1
+  fi
+}
+
+for path in "$build_workflow" "$signing_script" "$internal_group_script" "$fvm_config"; do
+  assert_file_exists "$path"
+done
+
+assert_contains "$build_workflow" 'DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer'
+assert_contains "$build_workflow" 'Validate App Store Xcode requirements'
+assert_contains "$build_workflow" 'Xcode 26 or later is required by App Store Connect'
+assert_contains "$build_workflow" 'iOS SDK 26 or later is required by App Store Connect'
+assert_contains "$build_workflow" '.fvm/fvm_config.json'
+assert_contains "$build_workflow" '.flutterSdkVersion'
+assert_contains "$build_workflow" '--config-only'
+assert_contains "$build_workflow" '-archivePath "$RUNNER_TEMP/Runner.xcarchive"'
+assert_contains "$build_workflow" 'ruby ../_release_automation/script/configure-ios-signing.rb'
+assert_contains "$build_workflow" '-exportArchive'
+assert_not_contains "$build_workflow" 'fvm flutter build ipa'
+assert_contains "$build_workflow" 'security find-identity -v -p codesigning'
+assert_contains "$build_workflow" 'TeamIdentifier'
+assert_contains "$build_workflow" 'ApplicationIdentifierPrefix'
+assert_contains "$build_workflow" 'ProvisionedDevices'
+assert_contains "$build_workflow" '<key>method</key><string>app-store-connect</string>'
+assert_contains "$build_workflow" '--skip_submission true'
+assert_contains "$build_workflow" 'assign-build'
+assert_contains "$build_workflow" 'assert-no-groups'
+assert_contains "$build_workflow" 'app-store-build-provenance-${{ github.run_id }}'
+assert_contains "$build_workflow" 'retention-days: 90'
+assert_contains "$build_workflow" 'if: always()'
+assert_contains "$build_workflow" 'APP_BUNDLE_ID'
+assert_contains "$build_workflow" 'APPLE_TEAM_ID'
+assert_contains "$build_workflow" 'TESTFLIGHT_INTERNAL_GROUP'
+assert_not_contains "$build_workflow" 'SUPABASE'
+assert_not_contains "$build_workflow" '.env'
+assert_not_contains "$build_workflow" '--dart-define-from-file'
+
+assert_contains "$internal_group_script" 'hasAccessToAllBuilds'
+assert_contains "$internal_group_script" 'add_build_to_beta_group'
+assert_contains "$signing_script" 'PRODUCT_BUNDLE_IDENTIFIER'
+assert_contains "$signing_script" 'APP_BUNDLE_ID'
+assert_contains "$signing_script" 'APPLE_TEAM_ID'
+
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  triggers = workflow["on"] || workflow[true]
+  raise "build workflow must only support workflow_call" unless triggers.keys == ["workflow_call"]
+  call = triggers.fetch("workflow_call")
+  %w[commit_sha distribute_internal submission_source caller_workflow_name caller_workflow_path].each do |name|
+    input = call.fetch("inputs").fetch(name)
+    raise "#{name} must be required" unless input.fetch("required") == true
+  end
+  raise "distribute_internal must be boolean" unless call.fetch("inputs").fetch("distribute_internal").fetch("type") == "boolean"
+  outputs = call.fetch("outputs")
+  %w[app_version build_number commit_sha build_id].each do |name|
+    raise "missing common build output #{name}" unless outputs.key?(name)
+  end
+  jobs = workflow.fetch("jobs")
+  preflight = jobs.fetch("preflight")
+  build = jobs.fetch("build")
+  raise "preflight must use Ubuntu" unless preflight.fetch("runs-on") == "ubuntu-24.04"
+  raise "iOS build must wait for preflight" unless build.fetch("needs") == "preflight"
+  raise "common build must use testflight environment" unless build.fetch("environment") == "testflight"
+  preflight_commands = preflight.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+  build_commands = build.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+  raise "preflight must run analyze" unless preflight_commands.include?("fvm flutter analyze")
+  raise "preflight must run tests" unless preflight_commands.include?("fvm flutter test")
+  raise "macOS build must not rerun analyze" if build_commands.include?("fvm flutter analyze")
+  raise "macOS build must not rerun tests" if build_commands.include?("fvm flutter test")
+  names = build.fetch("steps").map { |step| step.fetch("name") }
+  policy_index = names.index("Apply and verify TestFlight distribution policy")
+  provenance_index = names.index("Write build provenance")
+  raise "provenance must follow distribution verification" unless policy_index && provenance_index && policy_index < provenance_index
+  cleanup = build.fetch("steps").find { |step| step.fetch("name") == "Clean up signing materials" }
+  raise "signing cleanup must always run" unless cleanup.fetch("if") == "always()"
+  secrets = %w[
+    IOS_DISTRIBUTION_CERTIFICATE_BASE64
+    IOS_DISTRIBUTION_CERTIFICATE_PASSWORD
+    IOS_APP_STORE_PROVISIONING_PROFILE_BASE64
+    APP_STORE_CONNECT_ISSUER_ID
+    APP_STORE_CONNECT_KEY_ID
+    APP_STORE_CONNECT_PRIVATE_KEY
+  ]
+  leaked = secrets & build.fetch("env", {}).keys
+  raise "distribution secrets must not be job-scoped" unless leaked.empty?
+' "$build_workflow"
+
+printf 'TestFlight workflow tests passed\n'

--- a/script/testflight-workflows.test.sh
+++ b/script/testflight-workflows.test.sh
@@ -56,6 +56,9 @@ assert_contains "$build_workflow" 'assert-no-groups'
 assert_contains "$build_workflow" 'app-store-build-provenance-${{ github.run_id }}'
 assert_contains "$build_workflow" 'retention-days: 90'
 assert_contains "$build_workflow" 'if: always()'
+assert_contains "$build_workflow" 'ITSAppUsesNonExemptEncryption'
+assert_contains "$build_workflow" 'info["ITSAppUsesNonExemptEncryption"] = False'
+assert_contains "$build_workflow" 'plistlib'
 assert_contains "$build_workflow" 'APP_BUNDLE_ID'
 assert_contains "$build_workflow" 'APPLE_TEAM_ID'
 assert_contains "$build_workflow" 'TESTFLIGHT_INTERNAL_GROUP'
@@ -99,6 +102,9 @@ ruby -ryaml -e '
   policy_index = names.index("Apply and verify TestFlight distribution policy")
   provenance_index = names.index("Write build provenance")
   raise "provenance must follow distribution verification" unless policy_index && provenance_index && policy_index < provenance_index
+  compliance_index = names.index("Declare App Store export compliance")
+  archive_index = names.index("Build signed IPA")
+  raise "export compliance must be declared before archive" unless compliance_index < archive_index
   cleanup = build.fetch("steps").find { |step| step.fetch("name") == "Clean up signing materials" }
   raise "signing cleanup must always run" unless cleanup.fetch("if") == "always()"
   secrets = %w[

--- a/script/testflight-workflows.test.sh
+++ b/script/testflight-workflows.test.sh
@@ -49,7 +49,8 @@ assert_contains "$build_workflow" 'security find-identity -v -p codesigning'
 assert_contains "$build_workflow" 'TeamIdentifier'
 assert_contains "$build_workflow" 'ApplicationIdentifierPrefix'
 assert_contains "$build_workflow" 'ProvisionedDevices'
-assert_contains "$build_workflow" '<key>method</key><string>app-store-connect</string>'
+assert_contains "$build_workflow" '"method": "app-store-connect"'
+assert_contains "$build_workflow" 'plistlib.dump(options'
 assert_contains "$build_workflow" '--skip_submission true'
 assert_contains "$build_workflow" 'assign-build'
 assert_contains "$build_workflow" 'assert-no-groups'
@@ -62,6 +63,7 @@ assert_contains "$build_workflow" 'plistlib'
 assert_contains "$build_workflow" 'APP_BUNDLE_ID'
 assert_contains "$build_workflow" 'APPLE_TEAM_ID'
 assert_contains "$build_workflow" 'TESTFLIGHT_INTERNAL_GROUP'
+assert_contains "$build_workflow" 'Generate export options and App Store Connect key'
 assert_not_contains "$build_workflow" 'SUPABASE'
 assert_not_contains "$build_workflow" '.env'
 assert_not_contains "$build_workflow" '--dart-define-from-file'
@@ -118,5 +120,47 @@ ruby -ryaml -e '
   leaked = secrets & build.fetch("env", {}).keys
   raise "distribution secrets must not be job-scoped" unless leaked.empty?
 ' "$build_workflow"
+
+export_options_script="$(ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  step = workflow.fetch("jobs").fetch("build").fetch("steps").find do |candidate|
+    candidate["name"] == "Generate export options and App Store Connect key"
+  end
+  abort "export options step is missing" unless step
+  print step.fetch("run")
+' "$build_workflow")"
+[[ -n "$export_options_script" ]] || {
+  printf 'export options step must contain a run script\n' >&2
+  exit 1
+}
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+bundle_id="com.example.conquest"
+profile_name='Profile & <Release> "Beta"'
+RUNNER_TEMP="$fixture_root" \
+APP_BUNDLE_ID="$bundle_id" \
+APPLE_TEAM_ID="TEAM123456" \
+PROFILE_NAME="$profile_name" \
+APP_STORE_CONNECT_ISSUER_ID="issuer-fixture" \
+APP_STORE_CONNECT_KEY_ID="key-fixture" \
+APP_STORE_CONNECT_PRIVATE_KEY="private-key-fixture" \
+bash -c "$export_options_script"
+python3 - "$fixture_root/ExportOptions.plist" "$bundle_id" "$profile_name" <<'PY'
+import plistlib
+import sys
+
+path, bundle_id, expected_profile_name = sys.argv[1:]
+with open(path, "rb") as file:
+    options = plistlib.load(file)
+actual_profile_name = options["provisioningProfiles"][bundle_id]
+if actual_profile_name != expected_profile_name:
+    raise SystemExit(
+        f"profile name mismatch: {actual_profile_name!r} != {expected_profile_name!r}"
+    )
+if options["method"] != "app-store-connect":
+    raise SystemExit(f"unexpected export method: {options['method']!r}")
+if options["teamID"] != "TEAM123456":
+    raise SystemExit(f"unexpected team ID: {options['teamID']!r}")
+PY
 
 printf 'TestFlight workflow tests passed\n'

--- a/script/testflight_internal_group_test.rb
+++ b/script/testflight_internal_group_test.rb
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "stringio"
+require_relative "testflight-internal-group"
+
+class TestFlightInternalGroupTest < Minitest::Test
+  FakeClient = Struct.new(:group, :groups, :mutations, keyword_init: true) do
+    def find_app(bundle_id:)
+      raise "unexpected bundle" unless bundle_id == "com.conquest.conquest"
+
+      { "id" => "app-1" }
+    end
+
+    def find_beta_group(app_id:, name:)
+      raise "unexpected app" unless app_id == "app-1"
+      raise "unexpected group" unless name == "Internal"
+
+      group
+    end
+
+    def find_pre_release_version(app_id:, version:)
+      raise "unexpected version" unless app_id == "app-1" && version == "1.0.1"
+
+      { "id" => "pre-101" }
+    end
+
+    def find_build(pre_release_version_id:, build_number:)
+      raise "unexpected build" unless pre_release_version_id == "pre-101" && build_number == "123"
+
+      {
+        "id" => "build-123",
+        "attributes" => { "processingState" => "VALID", "expired" => false },
+      }
+    end
+
+    def beta_groups_for_build(build_id:)
+      raise "unexpected build ID" unless build_id == "build-123"
+
+      groups.shift || []
+    end
+
+    def add_build_to_beta_group(group_id:, build_id:)
+      mutations << [group_id, build_id]
+    end
+  end
+
+  def test_validate_manual_rejects_automatic_internal_group
+    client = fake_client(has_access_to_all_builds: true)
+    stderr = StringIO.new
+
+    status = cli(["validate-manual", "key.json", "com.conquest.conquest", "Internal"], client, stderr: stderr).run
+
+    assert_equal 1, status
+    assert_match(/Disable automatic distribution/, stderr.string)
+  end
+
+  def test_validate_manual_rejects_external_group
+    client = fake_client(is_internal_group: false)
+    stderr = StringIO.new
+
+    status = cli(["validate-manual", "key.json", "com.conquest.conquest", "Internal"], client, stderr: stderr).run
+
+    assert_equal 1, status
+    assert_match(/not internal/, stderr.string)
+  end
+
+  def test_assign_build_adds_exact_build_to_manual_internal_group
+    client = fake_client(groups: [[], [internal_group]])
+
+    status = cli(
+      ["assign-build", "key.json", "com.conquest.conquest", "Internal", "1.0.1", "123", "1"],
+      client,
+    ).run
+
+    assert_equal 0, status
+    assert_equal [["group-internal", "build-123"]], client.mutations
+  end
+
+  def test_assign_build_does_not_duplicate_existing_assignment
+    client = fake_client(groups: [[internal_group], [internal_group]])
+
+    status = cli(
+      ["assign-build", "key.json", "com.conquest.conquest", "Internal", "1.0.1", "123", "1"],
+      client,
+    ).run
+
+    assert_equal 0, status
+    assert_empty client.mutations
+  end
+
+  def test_assert_no_groups_rejects_any_testflight_assignment
+    client = fake_client(groups: [[internal_group]])
+    stderr = StringIO.new
+
+    status = cli(
+      ["assert-no-groups", "key.json", "com.conquest.conquest", "Internal", "1.0.1", "123", "1"],
+      client,
+      stderr: stderr,
+    ).run
+
+    assert_equal 1, status
+    assert_match(/must not belong to a TestFlight group/, stderr.string)
+  end
+
+  def test_assign_build_rejects_unprocessed_build_after_timeout
+    client = fake_client(groups: [[]])
+    client.define_singleton_method(:find_build) do |pre_release_version_id:, build_number:|
+      {
+        "id" => "build-123",
+        "attributes" => { "processingState" => "PROCESSING", "expired" => false },
+      }
+    end
+    stderr = StringIO.new
+
+    status = cli(
+      ["assign-build", "key.json", "com.conquest.conquest", "Internal", "1.0.1", "123", "1"],
+      client,
+      stderr: stderr,
+    ).run
+
+    assert_equal 1, status
+    assert_match(/PROCESSING/, stderr.string)
+  end
+
+  private
+
+  def cli(argv, client, stderr: StringIO.new)
+    TestFlightInternalGroup::CLI.new(
+      argv,
+      stdout: StringIO.new,
+      stderr: stderr,
+      sleep_fn: ->(_seconds) {},
+      client_factory: ->(_path) { client },
+    )
+  end
+
+  def fake_client(has_access_to_all_builds: false, is_internal_group: true, groups: [])
+    FakeClient.new(
+      group: internal_group(
+        has_access_to_all_builds: has_access_to_all_builds,
+        is_internal_group: is_internal_group,
+      ),
+      groups: groups,
+      mutations: [],
+    )
+  end
+
+  def internal_group(has_access_to_all_builds: false, is_internal_group: true)
+    {
+      "id" => "group-internal",
+      "attributes" => {
+        "name" => "Internal",
+        "isInternalGroup" => is_internal_group,
+        "hasAccessToAllBuilds" => has_access_to_all_builds,
+      },
+    }
+  end
+end


### PR DESCRIPTION
## 概要

main上の指定commitを手動で署名buildし、内部TestFlight配布またはApp Store審査直行へ進める4本のGitHub Actions workflowと、App Store Connect操作・署名・配布ポリシーの補助実装を追加します。

Apple審査への提出までを対象とし、承認後の公開はApp Store Connectから手動で行います。アプリUI・ゲームロジック・iOS project sourceには変更を加えていません。

## 背景・目的

ConquestにはApp Store用workflow、署名補助、App Store Connect操作が存在せず、内部TestFlightで確認したbuildと審査対象buildの同一性を証明する仕組みもありませんでした。本PRではIssue #46で承認された2経路を、fail-closed検証とprovenanceで実装します。

## 対応内容

- workflow_call専用の共有iOS App Store build workflowを追加
- 内部TestFlight配布、確認済みbuild提出、審査直行の3本の手動入口workflowを追加
- App Store version準備、build/metadata/review preflight、metadata更新をRuby serviceへ分離
- 手動内部TestFlightグループ検証、exact build割当、グループ未所属検証を追加
- 一時checkoutだけにRelease署名設定とexport compliance宣言を適用
- run ID・repository・workflow・main・target commit・version/build/build ID・配布状態をprovenance artifactで照合
- 初回設定、2経路、失敗/再実行、90日artifact期限、承認後手動公開をdocs/release.mdへ記載

## 主な設計判断

- 入口workflowはworkflow_dispatchのみ、共有buildはworkflow_callのみとし、push/mergeでApple側を自動変更しません。
- 対象commitはorigin/main履歴上の40文字SHAに限定し、署名・API key・Bundle ID・Team IDはGitHub Environmentから受け取ります。
- 内部経路は内部配布済みexact build、直行経路はTestFlightグループ未所属exact buildだけを許可します。
- 別versionのeditable/審査中状態、対象versionの別build紐付け、公開済み以下versionはbuild/upload前にfail-closeまたは明示skipします。
- automatic_releaseはfalseとし、release commandや承認後の公開workflowは追加しません。

## 受け入れ条件との対応

- [x] 4本のworkflowを追加し、3本の手動入口から共有buildを利用
- [x] main履歴上の40文字commit SHA以外ではApple側を変更しない
- [x] .fvm/fvm_config.jsonのFlutter 3.44.8でanalyze/test後に署名build
- [x] Bundle ID、Team ID、証明書、profile、API keyの実値をコードへ固定しない
- [x] TestFlight経路は内部配布済みの同一buildだけを審査提出
- [x] 審査直行経路は全TestFlightグループ未所属の同一buildだけを審査提出
- [x] 配布ポリシー確認後にprovenanceを保存し、Submit workflowで厳密照合
- [x] processing・期限・version/build・App Store state・metadata・審査競合をfail-closeで検証
- [x] 同じbuildへの再実行は既存審査を変更せず冪等成功
- [x] 一時署名・認証素材をalways cleanupで削除
- [x] automatic_release: false、承認後の自動公開workflowなし
- [x] Ruby unit test、workflow契約test、actionlint、shellcheck、Flutter analyze/test、no-codesign iOS buildが成功
- [x] docs/release.mdに初回設定、実行、失敗/再実行、承認後手動公開を記載
- [x] アプリUI、ゲームルール、ゲーム状態、iOS project sourceに差分なし

## 検証

- ruby script/app_store_release_test.rb: 30 runs / 94 assertions、成功
- ruby script/testflight_internal_group_test.rb: 6 runs / 17 assertions、成功
- bash script/testflight-workflows.test.sh: 成功
- bash script/app-store-review-workflow.test.sh: 成功
- bash script/direct-app-store-review-workflow.test.sh: 成功
- ruby -c script/configure-ios-signing.rb: 成功
- ruby -c script/testflight-internal-group.rb: 成功
- ruby -c script/app_store_release.rb: 成功
- actionlint .github/workflows/*.yml: 成功
- shellcheck script/*.sh: 成功
- fvm flutter analyze: 成功（No issues found）
- fvm flutter test: 171件成功
- fvm flutter build ios --release --no-codesign: 成功（Runner.app 15.2MB）
- git diff --check origin/main...HEAD: 成功

## レビュー結果

- Local final_reviewer: 承認（HEAD: 5a2b9fbfb74396d909aa26f3ffff76f23f0cc0ff）
- GitHub Codex review（1回のみ）: P2 3件を指摘対応済み（review HEAD: f958b722971b4452e333857a4cf6b5bcc40698c2、fix HEAD: 5a2b9fbfb74396d909aa26f3ffff76f23f0cc0ff）
- Required checks: 対象なし（current HEADのPR rollup、status、check-runs、Actions runsがすべて0件。mainのbranch protection/rulesetもなし）

## 残存リスク

実credentialを使うApple Distribution署名、App Store Connect API、IPA upload、TestFlight配布、審査提出は、認証情報未登録かつIssue対象外のため未実施です。初回live実行はdocs/release.mdの手順どおり内部TestFlight経路から確認する必要があります。またrepositoryにrequired checksがないため、GitHub側でcurrent HEADの検証を独立強制するCIゲートはありません。

Closes #46