### PR TITLE
TestFlight署名設定前のFlutterビルド失敗を修正する

### DIFF
--- a/.github/workflows/build-ios-app-store.yml
+++ b/.github/workflows/build-ios-app-store.yml
@@ -407,6 +407,7 @@ jobs:
           fvm flutter build ios \
             --release \
             --config-only \
+            --no-codesign \
             --build-name "$APP_VERSION" \
             --build-number "${{ github.run_id }}"
           APP_BUNDLE_ID="$APP_BUNDLE_ID" \

--- a/script/testflight-workflows.test.sh
+++ b/script/testflight-workflows.test.sh
@@ -121,6 +121,72 @@ ruby -ryaml -e '
   raise "distribution secrets must not be job-scoped" unless leaked.empty?
 ' "$build_workflow"
 
+build_step_script="$(ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  step = workflow.fetch("jobs").fetch("build").fetch("steps").find do |candidate|
+    candidate["name"] == "Build signed IPA"
+  end
+  abort "signed IPA build step is missing" unless step
+  print step.fetch("run")
+' "$build_workflow")"
+[[ -n "$build_step_script" ]] || {
+  printf 'signed IPA build step must contain a run script\n' >&2
+  exit 1
+}
+
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+mkdir -p "$fixture_root/bin" "$fixture_root/app"
+apply_stub="$fixture_root/bin/command-stub"
+cat > "$apply_stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf '%s' "$(basename "$0")"
+  printf '|%s' "$@"
+  printf '\n'
+} >> "$CALL_LOG"
+STUB
+chmod +x "$apply_stub"
+ln -s "$apply_stub" "$fixture_root/bin/fvm"
+ln -s "$apply_stub" "$fixture_root/bin/ruby"
+ln -s "$apply_stub" "$fixture_root/bin/xcodebuild"
+
+build_step_script="${build_step_script//'${{ github.run_id }}'/31456641285}"
+(
+  cd "$fixture_root/app"
+  PATH="$fixture_root/bin:$PATH" \
+  CALL_LOG="$fixture_root/build-calls.log" \
+  GITHUB_OUTPUT="$fixture_root/github-output" \
+  RUNNER_TEMP="$fixture_root/runner-temp" \
+  APP_BUNDLE_ID="com.yuto.conquest" \
+  APPLE_TEAM_ID="TEAM123456" \
+  PROFILE_NAME="Conquest App Store" \
+  APP_VERSION="1.2.3" \
+    bash -c "$build_step_script"
+)
+
+expected_config_call='fvm|flutter|build|ios|--release|--config-only|--no-codesign|--build-name|1.2.3|--build-number|31456641285'
+actual_config_call="$(sed -n '1p' "$fixture_root/build-calls.log")"
+[[ "$actual_config_call" == "$expected_config_call" ]] || {
+  printf 'Flutter config generation must disable signing before release signing is configured\nexpected: %s\nactual:   %s\n' \
+    "$expected_config_call" "$actual_config_call" >&2
+  exit 1
+}
+
+expected_signing_call='ruby|../_release_automation/script/configure-ios-signing.rb'
+actual_signing_call="$(sed -n '2p' "$fixture_root/build-calls.log")"
+[[ "$actual_signing_call" == "$expected_signing_call" ]] || {
+  printf 'release signing must be configured immediately after Flutter config generation\n' >&2
+  exit 1
+}
+
+archive_call="$(sed -n '3p' "$fixture_root/build-calls.log")"
+[[ "$archive_call" == xcodebuild*'|archive' ]] || {
+  printf 'signed archive must run after release signing is configured\n' >&2
+  exit 1
+}
+
 export_options_script="$(ruby -ryaml -e '
   workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
   step = workflow.fetch("jobs").fetch("build").fetch("steps").find do |candidate|
@@ -133,8 +199,6 @@ export_options_script="$(ruby -ryaml -e '
   printf 'export options step must contain a run script\n' >&2
   exit 1
 }
-fixture_root="$(mktemp -d)"
-trap 'rm -rf "$fixture_root"' EXIT
 bundle_id="com.example.conquest"
 profile_name='Profile & <Release> "Beta"'
 RUNNER_TEMP="$fixture_root" \


### PR DESCRIPTION
## 概要

TestFlight配布workflowで、Apple Distribution署名を設定する前のFlutter設定生成が開発署名を要求して停止する問題を修正します。

対象Run: https://github.com/yuto90/conquest/actions/runs/31456641285

## 原因

`Build signed IPA`ステップは、次の順で処理していました。

1. `fvm flutter build ios --release --config-only`
2. `configure-ios-signing.rb`でBundle ID、Team ID、Apple Distribution証明書、profileを設定
3. `xcodebuild archive`

しかし1の時点でFlutterがコード署名を要求し、`No valid code signing certificates were found`で停止していたため、2の配布署名設定へ到達できませんでした。証明書とプロビジョニングプロファイルの導入・検証自体は成功していました。

## 変更内容

- Flutterのconfig-only処理に`--no-codesign`を追加
- 実際のworkflow YAMLから`Build signed IPA`のshellを抽出・実行する回帰テストを追加
- Flutter設定生成が署名を無効化し、その後に配布署名設定、archiveの順で実行されることを検証

アプリコード、ゲームロジック、iOS project source、認証情報には変更を加えていません。

## 検証

- 回帰テストのRED: `--no-codesign`未指定を理由に期待どおり失敗
- `bash script/testflight-workflows.test.sh`
- `bash script/app-store-review-workflow.test.sh`
- `bash script/direct-app-store-review-workflow.test.sh`
- `ruby script/app_store_release_test.rb`: 30 runs / 94 assertions
- `ruby script/testflight_internal_group_test.rb`: 6 runs / 17 assertions
- `actionlint .github/workflows/*.yml`
- `shellcheck script/*.sh`
- `fvm flutter analyze`: No issues found
- `fvm flutter test`: 178 tests passed
- `fvm flutter build ios --release --no-codesign`: Runner.app 15.4MB
- `git diff --check origin/main...HEAD`

独立コードレビューではCritical・Important・Minorの指摘はありませんでした。

## 残存確認

GitHub-hosted runnerと登録済みcredentialを使う署名・archive・IPA export・TestFlight uploadの通し確認は、このPRをマージ後に新しいDeploy TestFlight Runで実施します。同じ失敗Runの再実行では修正コミットが利用されないため、新規Runが必要です。