### PR TITLE
fix: iOSリリース対象をiPhone専用にする

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -438,6 +439,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -456,6 +458,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/script/ios-app-store-project.test.sh
+++ b/script/ios-app-store-project.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project="$repo_root/ios/Runner.xcodeproj"
+
+for configuration in Debug Release Profile; do
+  device_family="$({
+    xcodebuild \
+      -project "$project" \
+      -target Runner \
+      -configuration "$configuration" \
+      -showBuildSettings
+  } | awk -F ' = ' '$1 ~ /^[[:space:]]*TARGETED_DEVICE_FAMILY$/ { print $2; exit }')"
+
+  if [[ "$device_family" != "1" ]]; then
+    printf 'Runner must be iPhone-only for %s builds; TARGETED_DEVICE_FAMILY was %s\n' \
+      "$configuration" "${device_family:-unset}" >&2
+    exit 1
+  fi
+done
+
+printf 'iOS App Store project tests passed\n'


### PR DESCRIPTION
## 概要

Conquest IslesのiOSターゲットをiPhone専用に変更し、App Store Connectでビルドが処理されない原因候補を解消します。

## 原因

Runnerターゲットがプロジェクト設定から`TARGETED_DEVICE_FAMILY = 1,2`（iPhone・iPad）を継承している一方、`Info.plist`は縦向きのみを宣言していました。そのためApp Store向けアーカイブで次の検証警告が発生していました。

`All interface orientations must be supported unless the app requires full screen.`

GitHub ActionsではIPAのアップロード自体は成功しましたが、App Store Connectにビルドが作成されず、処理待ちが30分でタイムアウトしていました。

## 変更内容

- RunnerのDebug／Release／Profileを`TARGETED_DEVICE_FAMILY = 1`へ統一
- 実際のXcodeビルド設定を読み取り、全構成がiPhone専用であることを検証する回帰テストを追加

## 影響

- App Store/TestFlight配布対象はiPhoneのみになります
- iPhone上のアプリ動作やゲームロジックは変更しません

## 検証

- iOS App Store project test
- TestFlight／App Store review workflow契約テスト
- Ruby tests: 30 runs / 94 assertions、6 runs / 17 assertions
- `actionlint`
- `shellcheck`
- `fvm flutter analyze`
- `fvm flutter test`: 178 tests passed
- 署名なしiOS Releaseビルド: 成功（Runner.app 15.4 MB）
- 署名なしReleaseアーカイブ: 成功、画面方向警告なし
- `git diff --check`

## 関連する失敗Run

- https://github.com/yuto90/conquest/actions/runs/31503766899/job/93821023219