### PR TITLE
Fix App Store version normalization

### DIFF
--- a/script/app_store_release_test.rb
+++ b/script/app_store_release_test.rb
@@ -131,6 +131,22 @@ class AppStoreReleaseTest < Minitest::Test
     assert_empty client.created_requests
   end
 
+  def test_prepare_reuses_semantically_equal_editable_version
+    client = FakeClient.new(
+      versions: [version("1.0", "PREPARE_FOR_SUBMISSION", id: "version-101")],
+      created_requests: [],
+      attached: nil,
+    )
+
+    result = successful_result("expected the existing 1.0 version to be reused") do
+      service(client).prepare_version(target_version: "1.0.0")
+    end
+
+    assert_equal :reused, result.action
+    assert_equal "version-101", result.version_id
+    assert_empty client.created_requests
+  end
+
   def test_prepare_reuses_existing_submitted_version_without_mutating_it
     client = FakeClient.new(
       versions: [
@@ -362,6 +378,33 @@ class AppStoreReleaseTest < Minitest::Test
     assert_equal "localization-ja", result.localization_id
   end
 
+  def test_preflight_treats_semantically_equal_submitted_version_as_target
+    client = release_client
+    client.versions.first["attributes"]["versionString"] = "0.9.0"
+    target = client.versions.last
+    target["attributes"]["versionString"] = "1.0"
+    target["attributes"]["appStoreState"] = "WAITING_FOR_REVIEW"
+    client.pre_release_version["attributes"]["version"] = "1.0.0"
+    client.attached = client.build
+    client.define_singleton_method(:find_pre_release_version) do |app_id:, version:|
+      raise "unexpected pre-release lookup" unless app_id == "app-1" && version == "1.0.0"
+
+      pre_release_version
+    end
+
+    result = successful_result("expected the existing 1.0 version to be reviewable") do
+      service(client).preflight(
+        app_version: "1.0.0",
+        build_number: "123",
+        internal_group: "Internal",
+        whats_new: "改善しました",
+      )
+    end
+
+    assert_equal :already_submitted, result.status
+    assert_equal "version-101", result.version_id
+  end
+
   def test_preflight_rejects_expired_build
     client = release_client
     client.build["attributes"]["expired"] = true
@@ -563,6 +606,12 @@ class AppStoreReleaseTest < Minitest::Test
 
   def service(client)
     AppStoreRelease::Service.new(client: client, bundle_id: "com.conquest.conquest")
+  end
+
+  def successful_result(message)
+    yield
+  rescue AppStoreRelease::Error => error
+    flunk "#{message}, got #{error.class}: #{error.message}"
   end
 
   def version(number, state, id: "version-#{number}")

--- a/script/lib/app_store_release.rb
+++ b/script/lib/app_store_release.rb
@@ -301,6 +301,10 @@ module AppStoreRelease
     raise ValidationError, "App version must be numeric x.y.z"
   end
 
+  def self.same_version?(left, right)
+    compare_versions(left, right).zero?
+  end
+
   class Service
     def initialize(client:, bundle_id:)
       @client = client
@@ -312,12 +316,15 @@ module AppStoreRelease
       app = @client.find_app(bundle_id: @bundle_id)
       app_id = app.fetch("id")
       versions = @client.app_store_versions(app_id: app_id)
-      exact = versions.find { |version| version_string(version) == target_version }
+      exact = versions.find do |version|
+        AppStoreRelease.same_version?(version_string(version), target_version)
+      end
       live = versions
              .select { |version| LIVE_STATES.include?(version_state(version)) }
              .max_by { |version| Gem::Version.new(version_string(version)) }
       submitted_conflicting = versions.find do |version|
-        version_string(version) != target_version && SUBMITTED_STATES.include?(version_state(version))
+        !AppStoreRelease.same_version?(version_string(version), target_version) &&
+          SUBMITTED_STATES.include?(version_state(version))
       end
       if submitted_conflicting
         raise ConflictError,
@@ -337,7 +344,8 @@ module AppStoreRelease
       end
 
       editable_conflicting = versions.find do |version|
-        version_string(version) != target_version && EDITABLE_STATES.include?(version_state(version))
+        !AppStoreRelease.same_version?(version_string(version), target_version) &&
+          EDITABLE_STATES.include?(version_state(version))
       end
       if editable_conflicting
         raise ConflictError,
@@ -401,7 +409,9 @@ module AppStoreRelease
       app = @client.find_app(bundle_id: @bundle_id)
       app_id = app.fetch("id")
       versions = @client.app_store_versions(app_id: app_id)
-      version = versions.find { |candidate| version_string(candidate) == app_version }
+      version = versions.find do |candidate|
+        AppStoreRelease.same_version?(version_string(candidate), app_version)
+      end
       raise ValidationError, "App Store version #{app_version} was not found" unless version
 
       state = version_state(version)
@@ -412,7 +422,8 @@ module AppStoreRelease
       raise ValidationError, "App Store version must use manual release" unless release_type == "MANUAL"
 
       conflicting = versions.find do |candidate|
-        version_string(candidate) != app_version && SUBMITTED_STATES.include?(version_state(candidate))
+        !AppStoreRelease.same_version?(version_string(candidate), app_version) &&
+          SUBMITTED_STATES.include?(version_state(candidate))
       end
       if conflicting
         raise ConflictError,


### PR DESCRIPTION
## Summary

- treat App Store Connect version strings such as `1.0` as semantically equal to app version `1.0.0`
- reuse the matching editable App Store version instead of reporting a false conflict
- apply the same version identity rule to App Store review preflight
- add regression coverage for prepare and submitted-version preflight

## Root cause

[Deploy TestFlight run 31515543340](https://github.com/yuto90/conquest/actions/runs/31515543340) uploaded, processed, and internally distributed build `1.0.0`, then failed while preparing the App Store version because the existing editable version was represented as `1.0` and compared as a raw string.

## Verification

- `ruby script/app_store_release_test.rb` — 32 runs, 100 assertions
- `ruby script/testflight_internal_group_test.rb` — 6 runs, 17 assertions
- TestFlight, App Store review, direct review, and iOS project contract tests
- Ruby syntax checks, `actionlint`, and `shellcheck`
- `fvm flutter analyze`
- `fvm flutter test --reporter failures-only` — 178 tests
- independent read-only review: no Critical, Important, or Minor findings

## Scope

No App Store Connect mutation, workflow rerun, review submission, or merge is performed by this PR.