### PR TITLE
Fix App Store version output extraction

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -104,10 +104,13 @@ jobs:
             --api-key-path "$RUNNER_TEMP/app-store-connect-key.json" \
             --bundle-id "$APP_BUNDLE_ID" \
             --app-version "$APP_VERSION")"
+          action="$(jq -r '.action' <<<"$result")"
+          version_id="$(jq -r '.version_id // ""' <<<"$result")"
+          message="$(jq -r '.message' <<<"$result")"
           {
-            echo "action=$(jq -r '.action' <<<"$result")"
-            echo "version_id=$(jq -r '.version_id // \"\"' <<<"$result")"
-            echo "message=$(jq -r '.message' <<<"$result")"
+            echo "action=$action"
+            echo "version_id=$version_id"
+            echo "message=$message"
           } >> "$GITHUB_OUTPUT"
 
       - name: Write App Store version preparation summary

--- a/script/app-store-review-workflow.test.sh
+++ b/script/app-store-review-workflow.test.sh
@@ -160,4 +160,95 @@ ruby -ryaml -e '
   raise "prepare must wait for build" unless prepare.fetch("needs") == "build"
 ' "$deploy_workflow"
 
+prepare_step_script="$(ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  step = workflow.fetch("jobs").fetch("prepare-app-store-version").fetch("steps").find do |candidate|
+    candidate["name"] == "Prepare App Store version"
+  end
+  abort "Prepare App Store version step is missing" unless step
+  print step.fetch("run")
+' "$deploy_workflow")"
+[[ -n "$prepare_step_script" ]] || {
+  printf 'Prepare App Store version step must contain a run script\n' >&2
+  exit 1
+}
+
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+stub_bin="$fixture_root/bin"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/ruby" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${PREPARE_FIXTURE:?}" in
+  present)
+    printf '%s' '{"action":"reused","version_id":"version-1","message":"App Store version already exists"}'
+    ;;
+  null)
+    printf '%s' '{"action":"created","version_id":null,"message":"App Store version created"}'
+    ;;
+  missing)
+    printf '%s' '{"action":"skipped","message":"App Store version skipped"}'
+    ;;
+  malformed)
+    printf '%s' '{malformed-json'
+    ;;
+  *)
+    printf 'unknown fixture: %s\n' "$PREPARE_FIXTURE" >&2
+    exit 2
+    ;;
+esac
+STUB
+chmod +x "$stub_bin/ruby"
+
+run_prepare_step() {
+  local fixture="$1"
+  local expected_status="$2"
+  local expected_output="$3"
+  local run_dir="$fixture_root/$fixture"
+  local status
+  local actual_output
+  mkdir -p "$run_dir"
+  : > "$run_dir/output"
+  if PREPARE_FIXTURE="$fixture" \
+    RUNNER_TEMP="$run_dir" \
+    APP_BUNDLE_ID="com.example.conquest" \
+    APP_VERSION="1.0.1" \
+    GITHUB_OUTPUT="$run_dir/output" \
+    PATH="$stub_bin:$PATH" \
+    bash -c "$prepare_step_script" > "$run_dir/stdout" 2> "$run_dir/stderr"; then
+    status=0
+  else
+    status=$?
+  fi
+  if [[ "$expected_status" == "nonzero" ]]; then
+    if [[ "$status" -eq 0 ]]; then
+      printf '%s fixture unexpectedly succeeded\n' "$fixture" >&2
+      cat "$run_dir/stderr" >&2
+      return 1
+    fi
+    if [[ -s "$run_dir/output" ]]; then
+      printf '%s fixture must not write GITHUB_OUTPUT on failure\n' "$fixture" >&2
+      cat "$run_dir/output" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if [[ "$status" -ne "$expected_status" ]]; then
+    printf '%s fixture returned status %s, expected %s\n' "$fixture" "$status" "$expected_status" >&2
+    cat "$run_dir/stderr" >&2
+    return 1
+  fi
+  actual_output="$(<"$run_dir/output")"
+  if [[ "$actual_output" != "$expected_output" ]]; then
+    printf '%s fixture output was %q, expected %q\n' "$fixture" "$actual_output" "$expected_output" >&2
+    return 1
+  fi
+}
+
+run_prepare_step present 0 $'action=reused\nversion_id=version-1\nmessage=App Store version already exists'
+run_prepare_step null 0 $'action=created\nversion_id=\nmessage=App Store version created'
+run_prepare_step missing 0 $'action=skipped\nversion_id=\nmessage=App Store version skipped'
+run_prepare_step malformed nonzero ''
+
 printf 'App Store review workflow tests passed\n'


### PR DESCRIPTION
## 概要

`Prepare App Store version` ステップの `version_id` 出力で発生していた jq 構文エラーと、解析失敗が成功として隠れる問題を修正します。

## 背景・目的

Issue #51 で確認されたとおり、無効な jq フィルターが `echo` のコマンド置換内で実行されていたため、`version_id` が空のままでもステップが成功していました。本変更では出力契約を復旧し、不正JSONをfail-closedで扱います。

## 対応内容

- `action`、`version_id`、`message` を個別の jq 実行で先に抽出
- `version_id` のフィルターを有効な `.version_id // ""` へ修正
- YAMLに定義された実際の `Prepare App Store version` runスクリプトを実行する回帰テストを追加
- `version_id` が存在・null・キーなし・不正JSONの各ケースをcontrolled fixtureで検証

## 主な設計判断

- jq抽出を出力書き込みより前に完了させ、どのJSON解析失敗でも部分出力せず非0終了させます。
- 外部API呼び出しだけをRubyスタブへ差し替え、実際のworkflow shellと既存のcreated/reused/skipped処理を検証対象に保ちます。

## 受け入れ条件との対応

- [x] `version_id` が存在するJSONでは値を正確に出力
- [x] `version_id: null` またはキーなしでは空文字列を出力
- [x] 不正JSONまたはjq解析失敗時は非0終了
- [x] `action` と `message` の既存出力を維持
- [x] `created`、`reused`、`skipped` の既存挙動を維持
- [x] `actionlint`、`shellcheck`、既存のリリース関連テストが成功

## 検証

- `bash script/app-store-review-workflow.test.sh`: 成功
- `ruby script/app_store_release_test.rb`: 成功（32 runs / 100 assertions）
- `ruby script/testflight_internal_group_test.rb`: 成功（6 runs / 17 assertions）
- `bash script/direct-app-store-review-workflow.test.sh`: 成功
- `bash script/testflight-workflows.test.sh`: 成功
- `bash script/ios-app-store-project.test.sh`: 成功
- `actionlint`: 成功
- `shellcheck script/app-store-review-workflow.test.sh`: 成功
- `fvm flutter analyze`: 成功（No issues found）
- `fvm flutter test`: 成功（178 tests）
- `git diff --check origin/main...HEAD`: 成功

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `4e7baee0a4be0cbc6c68c2c944c97a5ba47319f6`）
- GitHub Codex review（1回のみ）: 指摘なし（review HEAD: `4e7baee0a4be0cbc6c68c2c944c97a5ba47319f6`）
- Required checks: 対象なし（current HEADのPR rollup、check-runs、commit status、branch上のActions runsがすべて0件。mainのbranch protection/rulesetもなし）

## 残存リスク

controlled fixtureによるローカル契約検証のみで、GitHub Actions実ランナーとApple API実レスポンスを用いた統合実行は未確認です。App Store Connect live操作、TestFlight配布、審査提出は実施していません。

Closes #51
